### PR TITLE
fix usleep error on linux systems

### DIFF
--- a/src/java.cpp
+++ b/src/java.cpp
@@ -1,6 +1,7 @@
 
 #include "java.h"
 #include <string.h>
+#include <unistd.h>
 #include "javaObject.h"
 #include "methodCallBaton.h"
 #include "node_NodeDynamicProxyClass.h"


### PR DESCRIPTION
I tried to install with npm, but got the error

``` plaintext
/src/java.cpp: In function ‘void my_sleep(int)’:
/src/java.cpp:18:13: error: ‘usleep’ was not declared in this scope
```

I had to include `unistd.h` to make it work (using Fedora 17 Linux).
