### PR TITLE
Fix: WARNING in native method: JNI call made with exception pending

### DIFF
--- a/src/methodCallBaton.cpp
+++ b/src/methodCallBaton.cpp
@@ -82,7 +82,6 @@ v8::Handle<v8::Value> MethodCallBaton::resultsToV8(JNIEnv *env) {
 
   if(m_error) {
     v8::Handle<v8::Value> err = javaExceptionToV8(env, m_error, m_errorString);
-    env->DeleteGlobalRef(m_error);
     return scope.Close(err);
   }
 
@@ -96,9 +95,8 @@ void NewInstanceBaton::execute(JNIEnv *env) {
   //printf("invoke: %s\n", javaMethodCallToString(env, m_method, constructor_newInstance, m_args).c_str());
 
   jobject result = env->CallObjectMethod(m_method, constructor_newInstance, m_args);
-  jthrowable err = env->ExceptionOccurred();
-  if(err) {
-    m_error = (jthrowable)env->NewGlobalRef(err);
+  if(env->ExceptionCheck()) {
+    m_error = env->ExceptionOccurred();
     m_errorString = "Error creating class";
     env->ExceptionClear();
     return;
@@ -121,9 +119,8 @@ void StaticMethodCallBaton::execute(JNIEnv *env) {
 
   jobject result = env->CallObjectMethod(m_method, method_invoke, NULL, m_args);
 
-  jthrowable err = env->ExceptionOccurred();
-  if(err) {
-    m_error = (jthrowable)env->NewGlobalRef(err);
+  if(env->ExceptionCheck()) {
+    m_error = env->ExceptionOccurred();
     m_errorString = "Error running static method";
     env->ExceptionClear();
     return;
@@ -146,9 +143,8 @@ void InstanceMethodCallBaton::execute(JNIEnv *env) {
 
   jobject result = env->CallObjectMethod(m_method, method_invoke, m_javaObject->getObject(), m_args);
 
-  jthrowable err = env->ExceptionOccurred();
-  if(err) {
-    m_error = (jthrowable)env->NewGlobalRef(err);
+  if(env->ExceptionCheck()) {
+    m_error = env->ExceptionOccurred();
     m_errorString = "Error running instance method";
     env->ExceptionClear();
     return;


### PR DESCRIPTION
If an exception is thrown from within the Java code, the "NewGlobalRef()" call caused the following warning (With option -Xcheck:jni):
WARNING in native method: JNI call made with exception pending

This change removes the native call to "NewGlobalRef()" while there's an exception and replace it with a call to "ExceptionDescribe()" which is safe while there's an exception pending.
