### PR TITLE
Fix compilation error with some versions of node-0.9

### DIFF
--- a/src/java.cpp
+++ b/src/java.cpp
@@ -737,7 +737,7 @@ JNIEXPORT jobject JNICALL Java_node_NodeDynamicProxyClass_callJs(JNIEnv *env, jo
     EIO_AfterCallJs(req);
 #endif
   } else {
-    uv_queue_work(uv_default_loop(), req, EIO_CallJs, EIO_AfterCallJs);
+    uv_queue_work(uv_default_loop(), req, EIO_CallJs, (uv_after_work_cb)EIO_AfterCallJs);
 
     while(!dynamicProxyData->done) {
       my_sleep(100);

--- a/src/methodCallBaton.cpp
+++ b/src/methodCallBaton.cpp
@@ -30,7 +30,7 @@ MethodCallBaton::~MethodCallBaton() {
 void MethodCallBaton::run() {
   uv_work_t* req = new uv_work_t();
   req->data = this;
-  uv_queue_work(uv_default_loop(), req, MethodCallBaton::EIO_MethodCall, MethodCallBaton::EIO_AfterMethodCall);
+  uv_queue_work(uv_default_loop(), req, MethodCallBaton::EIO_MethodCall, (uv_after_work_cb)MethodCallBaton::EIO_AfterMethodCall);
 }
 
 v8::Handle<v8::Value> MethodCallBaton::runSync() {


### PR DESCRIPTION
`node-java` compilation fails with node versions between `v0.9.4` and `v0.9.12`. Tested with binary donwloadable versions from the [official site](http://nodejs.org/dist/). Gives the following error:

```
make: Entering directory `~/forks/node-java/build'
  ACTION Verify Deps build/depsVerified
  CXX(target) Release/obj.target/nodejavabridge_bindings/src/java.o
../src/java.cpp: In function ‘_jobject* Java_node_NodeDynamicProxyClass_callJs(JNIEnv*, _jobject*, jlong, _jobject*, _jobjectArray*)’:
../src/java.cpp:740: error: invalid conversion from ‘void (*)(uv_work_t*)’ to ‘void (*)(uv_work_t*, int)’
../src/java.cpp:740: error: initializing argument 4 of ‘int uv_queue_work(uv_loop_t*, uv_work_t*, void (*)(uv_work_t*), void (*)(uv_work_t*, int))’
make: *** [Release/obj.target/nodejavabridge_bindings/src/java.o] Error 1
make: Leaving directory `~/forks/node-java/build'
```

This PR solves the problem. Tested to work with multiple node versions between `v.0.6.0` and `v.0.11.1`.

Perhaps related with the issue #43.
