### PR TITLE
store jthrowable instances as global references

### DIFF
--- a/src/methodCallBaton.cpp
+++ b/src/methodCallBaton.cpp
@@ -21,7 +21,9 @@ MethodCallBaton::~MethodCallBaton() {
   if(m_result) {
     env->DeleteGlobalRef(m_result);
   }
-
+  if(m_error) {
+    env->DeleteGlobalRef(m_error);
+  }
   env->DeleteGlobalRef(m_args);
   env->DeleteGlobalRef(m_method);
   m_callback.Dispose();
@@ -98,9 +100,10 @@ void NewInstanceBaton::execute(JNIEnv *env) {
 
   jobject result = env->CallObjectMethod(m_method, constructor_newInstance, m_args);
   if(env->ExceptionCheck()) {
-    m_error = env->ExceptionOccurred();
-    m_errorString = "Error creating class";
+    jthrowable ex = env->ExceptionOccurred();
     env->ExceptionClear();
+    m_error = (jthrowable)env->NewGlobalRef(ex);
+    m_errorString = "Error creating class";
     return;
   }
 
@@ -122,9 +125,10 @@ void StaticMethodCallBaton::execute(JNIEnv *env) {
   jobject result = env->CallObjectMethod(m_method, method_invoke, NULL, m_args);
 
   if(env->ExceptionCheck()) {
-    m_error = env->ExceptionOccurred();
-    m_errorString = "Error running static method";
+    jthrowable ex = env->ExceptionOccurred();
     env->ExceptionClear();
+    m_error = (jthrowable)env->NewGlobalRef(ex);
+    m_errorString = "Error running static method";
     return;
   }
 
@@ -146,9 +150,10 @@ void InstanceMethodCallBaton::execute(JNIEnv *env) {
   jobject result = env->CallObjectMethod(m_method, method_invoke, m_javaObject->getObject(), m_args);
 
   if(env->ExceptionCheck()) {
-    m_error = env->ExceptionOccurred();
-    m_errorString = "Error running instance method";
+    jthrowable ex = env->ExceptionOccurred();
     env->ExceptionClear();
+    m_error = (jthrowable)env->NewGlobalRef(ex);
+    m_errorString = "Error running instance method";
     return;
   }
 


### PR DESCRIPTION
https://github.com/nearinfinity/node-java/pull/45 appears to have attempted to resolve one issue with exceptions. However, in doing so it stored a local reference to the exception, which is then subject to GC after the current stack frame exits.

For me, this was causing seg faults when doing a large amount of parallel processing with node-java.

After reading through http://mail-archives.apache.org/mod_mbox/harmony-dev/200703.mbox/%3Cb6cb498e0703230901i28180bdft1e698283fc318493@mail.gmail.com%3E it appears the correct fix is to store a local reference to the exception handle, clear the exception, and then to create a global reference to the exception handle.

This resolves both the issue in #45 as well as the current seg faults due to the local reference storage.
