### PR TITLE
added newFloat method

### DIFF
--- a/src/java.h
+++ b/src/java.h
@@ -32,6 +32,7 @@ private:
   static v8::Handle<v8::Value> newByte(const v8::Arguments& args);
   static v8::Handle<v8::Value> newChar(const v8::Arguments& args);
   static v8::Handle<v8::Value> newShort(const v8::Arguments& args);
+  static v8::Handle<v8::Value> newFloat(const v8::Arguments& args);
   static v8::Handle<v8::Value> getStaticFieldValue(const v8::Arguments& args);
   static v8::Handle<v8::Value> setStaticFieldValue(const v8::Arguments& args);
   v8::Handle<v8::Value> ensureJvm();


### PR DESCRIPTION
The gremlin-node project was wrapping some Java interfaces and enabling passing floats by passing strings formatted as "1.0f" for example. However, it seems to make more sense to follow the convention of newByte, newShort, etc. and have a method as part of node-java for creating floats easily.
