### PR TITLE
added somewhat excessive env->ExceptionCheck checks

### DIFF
--- a/src/java.cpp
+++ b/src/java.cpp
@@ -214,6 +214,7 @@ void Java::destroyJVM(JavaVM** jvm, JNIEnv** env) {
   jclass classClazz = env->FindClass("java/lang/ClassLoader");
   jmethodID class_getClassLoader = env->GetStaticMethodID(classClazz, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
   jobject classLoader = env->CallStaticObjectMethod(classClazz, class_getClassLoader);
+  assert(!env->ExceptionCheck());
 
   jobject result = env->NewGlobalRef(classLoader);
   return scope.Close(javaToV8(self, env, result));
@@ -504,6 +505,7 @@ void Java::destroyJVM(JavaVM** jvm, JNIEnv** env) {
       jmethodID byte_byteValue = env->GetMethodID(byteClazz, "byteValue", "()B");
       jbyte byteValues[1];
       byteValues[0] = env->CallByteMethod(val, byte_byteValue);
+      assert(!env->ExceptionCheck());
       env->SetByteArrayRegion((jbyteArray)results, i, 1, byteValues);
     }
   }
@@ -517,6 +519,7 @@ void Java::destroyJVM(JavaVM** jvm, JNIEnv** env) {
       jmethodID string_charAt = env->GetMethodID(stringClazz, "charAt", "(I)C");
       jchar itemValues[1];
       itemValues[0] = env->CallCharMethod(val, string_charAt, 0);
+      assert(!env->ExceptionCheck());
       env->SetCharArrayRegion((jcharArray)results, i, 1, itemValues);
     }
   }
@@ -530,6 +533,7 @@ void Java::destroyJVM(JavaVM** jvm, JNIEnv** env) {
       jmethodID short_shortValue = env->GetMethodID(shortClazz, "shortValue", "()S");
       jshort shortValues[1];
       shortValues[0] = env->CallShortMethod(val, short_shortValue);
+      assert(!env->ExceptionCheck());
       env->SetShortArrayRegion((jshortArray)results, i, 1, shortValues);
     }
   }
@@ -543,6 +547,7 @@ void Java::destroyJVM(JavaVM** jvm, JNIEnv** env) {
       jmethodID boolean_booleanValue = env->GetMethodID(booleanClazz, "booleanValue", "()Z");
       jboolean booleanValues[1];
       booleanValues[0] = env->CallBooleanMethod(val, boolean_booleanValue);
+      assert(!env->ExceptionCheck());
       env->SetBooleanArrayRegion((jbooleanArray)results, i, 1, booleanValues);
     }
   }
@@ -933,6 +938,7 @@ JNIEXPORT jobject JNICALL Java_node_NodeDynamicProxyClass_callJs(JNIEnv *env, jo
   jclass methodClazz = env->FindClass("java/lang/reflect/Method");
   jmethodID method_getName = env->GetMethodID(methodClazz, "getName", "()Ljava/lang/String;");
   dynamicProxyData->methodName = javaObjectToString(env, env->CallObjectMethod(method, method_getName));
+  assert(!env->ExceptionCheck());
 
   uv_work_t* req = new uv_work_t();
   req->data = dynamicProxyData;

--- a/src/javaObject.cpp
+++ b/src/javaObject.cpp
@@ -21,6 +21,7 @@
   jclass classClazz = env->FindClass("java/lang/Class");
   jmethodID class_getName = env->GetMethodID(classClazz, "getName", "()Ljava/lang/String;");
   jobject classNameJava = env->CallObjectMethod(objClazz, class_getName);
+  assert(!env->ExceptionCheck());
   std::string className = javaObjectToString(env, classNameJava);
   std::replace(className.begin(), className.end(), '.', '_');
   std::replace(className.begin(), className.end(), '$', '_');
@@ -44,6 +45,7 @@
     jmethodID method_getName = env->GetMethodID(methodClazz, "getName", "()Ljava/lang/String;");
     for(std::list<jobject>::iterator it = methods.begin(); it != methods.end(); ++it) {
       jstring methodNameJava = (jstring)env->CallObjectMethod(*it, method_getName);
+      assert(!env->ExceptionCheck());
       std::string methodNameStr = javaToString(env, methodNameJava);
 
       v8::Handle<v8::String> methodName = v8::String::New(methodNameStr.c_str());
@@ -61,6 +63,7 @@
     jmethodID field_getName = env->GetMethodID(fieldClazz, "getName", "()Ljava/lang/String;");
     for(std::list<jobject>::iterator it = fields.begin(); it != fields.end(); ++it) {
       jstring fieldNameJava = (jstring)env->CallObjectMethod(*it, field_getName);
+      assert(!env->ExceptionCheck());
       std::string fieldNameStr = javaToString(env, fieldNameJava);
 
       v8::Handle<v8::String> fieldName = v8::String::New(fieldNameStr.c_str());

--- a/src/methodCallBaton.cpp
+++ b/src/methodCallBaton.cpp
@@ -93,6 +93,7 @@ v8::Handle<v8::Value> MethodCallBaton::resultsToV8(JNIEnv *env) {
       jclass throwableClazz = env->FindClass("java/lang/Throwable");
       jmethodID throwable_getCause = env->GetMethodID(throwableClazz, "getCause", "()Ljava/lang/Throwable;");
       cause = (jthrowable)env->CallObjectMethod(m_error, throwable_getCause);
+      assert(!env->ExceptionCheck());
     }
 
     v8::Handle<v8::Value> err = javaExceptionToV8(m_java, env, cause, m_errorString);


### PR DESCRIPTION
I was tracking down a pesky issue earlier, and while doing so I added checks to env->ExceptionCheck after _every_  `env->Call*` invocation.

This is somewhat ugly, but it ultimately aided me in tracking down my issue. Any thoughts?
