### PR TITLE
Update to the latest version of find-java-home

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/joeferner/node-java.git"
   },
   "dependencies": {
-    "find-java-home": "0.0.3"
+    "find-java-home": "0.0.6"
   },
   "devDependencies": {
     "nodeunit": "~0.6.4",


### PR DESCRIPTION
latest version of find-java-home has fixes for linux distros with deep symbolic links
