### PR TITLE
bumping find-java-home to 0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/joeferner/node-java.git"
   },
   "dependencies": {
-    "find-java-home": "0.0.6"
+    "find-java-home": "0.0.7"
   },
   "devDependencies": {
     "nodeunit": "~0.6.4",


### PR DESCRIPTION
It was discovered that find-java-home was blindly accepting JAVA_HOME without performing a check first.
