### PR TITLE
Fix typo in the example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ __Arguments__
 
 __Example__
 
-    java.getStaticFieldValue("com.nearinfinty.MyClass", "data", "Hello World");
+    java.setStaticFieldValue("com.nearinfinty.MyClass", "data", "Hello World");
 
 <a name="javaNewArray" />
 **java.newArray(className, values[])**


### PR DESCRIPTION
Just a small typo in the provided example for setStaticFieldValue in the readme.
