### PR TITLE
Fix for windows installs.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -34,19 +34,6 @@
       'conditions': [
         ['OS=="win"',
           {
-            'actions': [
-              {
-                'action_name': 'verifyDeps',
-                'inputs': [
-                  '<(javahome)/lib/jvm.lib',
-                  '<(javahome)/include/jni.h',
-                  '<(javahome)/include/win32/jni_md.h'
-                ],
-                'outputs': ['./build/depsVerified'],
-                'action': ['python', 'touch.py'],
-                'message': 'Verify Deps'
-              }
-            ],
             'include_dirs': [
               '<(javahome)/include/win32',
             ],

--- a/touch.py
+++ b/touch.py
@@ -1,5 +1,0 @@
-import os;
-
-f = open('depsVerified', 'w');
-f.write('ok');
-f.close();


### PR DESCRIPTION
python wasn't getting found properly from within binding.gyp.

@joeferner can you give me some background on this file?  I was able to install `microtime` without issues, but `node-java` failed with `cannot find python`.  I think this could be a PATH bug within `node-gyp` or something, but I was able to install just fine without this action.
