### PR TITLE
Adding support for zLinux and PowerPC

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,12 @@
       ['target_arch=="ia32"', {
         'arch%': 'i386'
       }],
+      ['"<!(uname -m)"=="s390" or "<!(uname -m)"=="s390x"', {
+        'target_arch': 's390'
+      }],
+      ['"<!(uname -m)"=="ppc64" or "<!(uname -m)"=="ppc64le"', {
+        'target_arch': 'ppc64'
+      }],
       ['OS=="win"', {
         'javahome%': '<!(node findJavaHome.js)'
       }],
@@ -19,6 +25,12 @@
       }],
       ['OS=="linux" and target_arch=="x64"', {
         'javalibdir%': "<!(h=\"`node findJavaHome.js`\" sh -c 'if [ -d \"$h/jre/lib/amd64/classic\" ]; then echo $h/jre/lib/amd64/classic; else echo $h/jre/lib/amd64/server; fi')"
+      }],
+      ['OS=="linux" and (target_arch=="s390x" or target_arch=="s390")', {
+        'javalibdir%': "<!(h=\"`node findJavaHome.js`\" sh -c 'if [ -d \"$h/jre/lib/s390x/classic\" ]; then echo $h/jre/lib/s390x/classic; else echo $h/jre/lib/s390/classic; fi')"
+      }],
+      ['OS=="linux" and (target_arch=="ppc64" or target_arch=="ppc")', {
+        'javalibdir%': "<!(h=\"`node findJavaHome.js`\" sh -c 'if [ -d \"$h/jre/lib/ppc64/classic\" ]; then echo $h/jre/lib/ppc64/classic; fi')"
       }]
     ]
   },


### PR DESCRIPTION
The only changes were made in `binding.gyp`, just a couple of extra checks. It should not affect installation on the mainstream systems in any way. I've only been able to check it on Ubuntu 12.04, x86_64, but can't see why it would be different for any other OS.

For testing:

```
npm install CGavrila/node-java
```

Edit:
If there are any issues or concerns, please share.

Thank you,
Cristian
