### PR TITLE
Use better test for UnsupportedClassVersionError.

### DIFF
--- a/test8/testLambda.js
+++ b/test8/testLambda.js
@@ -14,7 +14,7 @@ exports['Java8'] = nodeunit.testCase({
       test.equal(diff, -19);
     }
     catch (err) {
-      var unsupportedVersion = err.toString().match(/Unsupported major.minor version 52.0/)
+      var unsupportedVersion = java.instanceOf(err.cause, 'java.lang.UnsupportedClassVersionError');
       test.ok(unsupportedVersion);
       if (unsupportedVersion)
         console.log('JRE 1.8 not available');


### PR DESCRIPTION
The previous test worked correctly with the Oracle JVM but
failed with other JVMs. This new test should work correctly
on all JVMs.

Should fix issue #172.
