### PR TITLE
First rough draft of adding support for promises.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,48 @@ try {
 }
 ```
 
+### Promises
+
+As of release 0.4.5 it is possible to create async methods that return promises by setting the asyncOptions property of the java object.
+
+Example:
+
+```javascript
+var java = require("java");
+java.asyncOptions = {
+  promiseSuffix: 'Promise',
+  promisify: require('when/node').lift
+};
+java.classpath.push("commons-lang3-3.1.jar");
+java.classpath.push("commons-io.jar");
+
+java.newInstancePromise("java.util.ArrayList")
+    .then(function(list) { return list.addPromise("item1"); })
+    .then(function(list) { return list.addPromise("item2"); })
+    .catch(function(err) { /* handle error */ });
+```
+
+* If you don't need promise-returning methods, simply leave java.asyncOptions unset.
+* Sync and standard async methods are still generated as in previous releases. In the future we may provide the option to disable generation of standard async methods.
+* You are free to choose whatever non-empty suffix you want for the promise-returning methods, but you must specify a value.
+* asyncOptions.promisify must be a function that given a node.js style async function as input returns a function that returns a promise that is resolved (or rejected) when the async function has completed. Several Promises libraries provide such functions. This *should* just work, but at the moment one prominent promises library doesn't.
+* Note that it should be possible to mix use of two different Promises/A+ conforming libraries. You may be able to use one library for installing the asyncOptions.promisify function, and then use another library everywhere else in your application.
+
+#### Tested Promises Libraries
+
+##### [when](https://www.npmjs.com/package/when)
+We use this package in our unit tests, and it passes under all 9 cases of our [test matrix](https://travis-ci.org/joeferner/node-java).
+
+`promisify: require('when/node').lift`
+
+##### [bluebird](https://www.npmjs.com/package/bluebird)
+Does not work with node 0.8, but works with node 0.10 and 0.11.
+
+`promisify: require('bluebird').promisify`
+
+##### [Q](https://www.npmjs.com/package/q)
+Unfortunately, the popular Q promises library currently does **NOT** work.
+
 # Release Notes
 
 ### v0.2.0

--- a/lib/nodeJavaBridge.js
+++ b/lib/nodeJavaBridge.js
@@ -46,7 +46,7 @@ java.import = function(name) {
   var promiseSuffix;
   if (java.asyncOptions && java.asyncOptions.promisify) {
     promisify = java.asyncOptions.promisify;
-    promiseSuffix = java.asyncOptions.suffix;
+    promiseSuffix = java.asyncOptions.promiseSuffix;
   }
 
   // copy static methods

--- a/lib/nodeJavaBridge.js
+++ b/lib/nodeJavaBridge.js
@@ -42,6 +42,13 @@ java.import = function(name) {
     }
   }
 
+  var promisify = undefined;
+  var promiseSuffix;
+  if (java.asyncOptions && java.asyncOptions.promisify) {
+    promisify = java.asyncOptions.promisify;
+    promiseSuffix = java.asyncOptions.suffix;
+  }
+
   // copy static methods
   var methods = clazz.getDeclaredMethodsSync();
   for (i = 0; i < methods.length; i++) {
@@ -50,6 +57,9 @@ java.import = function(name) {
       var methodName = methods[i].getNameSync();
       result[methodName + 'Sync'] = java.callStaticMethodSync.bind(java, name, methodName);
       result[methodName] = java.callStaticMethod.bind(java, name, methodName);
+      if (promisify) {
+        result[methodName + promiseSuffix] = promisify(java.callStaticMethod.bind(java, name, methodName));
+      }
     }
   }
 

--- a/lib/nodeJavaBridge.js
+++ b/lib/nodeJavaBridge.js
@@ -11,6 +11,19 @@ java.classpath.push(path.resolve(__dirname, "../commons-lang3-node-java.jar"));
 java.classpath.push(path.resolve(__dirname, __dirname, "../src-java"));
 java.nativeBindingLocation = binaryPath;
 
+java.onJvmCreated = function() {
+  if (java.asyncOptions) {
+    var suffix = java.asyncOptions.promiseSuffix;
+    var promisify = java.asyncOptions.promisify;
+    if (typeof suffix === 'string' && typeof promisify === 'function') {
+      var methods = ['newInstance', 'callMethod', 'callStaticMethod'];
+      methods.forEach(function (name) {
+        java[name + suffix] = promisify(java[name]);
+      });
+    }
+  }
+}
+
 var MODIFIER_PUBLIC = 1;
 var MODIFIER_STATIC = 8;
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "devDependencies": {
     "async": "~0.1.22",
-    "bluebird": "^2.6.0",
-    "nodeunit": "0.9.0"
+    "nodeunit": "0.9.0",
+    "when": "~3.6.4"
   },
   "scripts": {
     "test": "nodeunit test test8",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "async": "~0.1.22",
+    "bluebird": "^2.6.0",
     "nodeunit": "0.9.0"
   },
   "scripts": {

--- a/src/java.cpp
+++ b/src/java.cpp
@@ -112,9 +112,9 @@ v8::Local<v8::Value> Java::createJVM(JavaVM** jvm, JNIEnv** env) {
     if (!promisify->IsFunction()) {
       return NanTypeError("asyncOptions.promisify must be a function");
     }
-    v8::Local<v8::Value> suffix = asyncOptionsObj->Get(NanNew<v8::String>("suffix"));
+    v8::Local<v8::Value> suffix = asyncOptionsObj->Get(NanNew<v8::String>("promiseSuffix"));
     if (!suffix->IsString()) {
-      return NanTypeError("asyncOptions.suffix must be a string");
+      return NanTypeError("asyncOptions.promiseSuffix must be a string");
     }
     NanAssignPersistent(m_asyncOptions, asyncOptionsObj);
   }

--- a/src/java.cpp
+++ b/src/java.cpp
@@ -107,7 +107,7 @@ v8::Local<v8::Value> Java::createJVM(JavaVM** jvm, JNIEnv** env) {
 
   v8::Local<v8::Value> asyncOptions = NanObjectWrapHandle(this)->Get(NanNew<v8::String>("asyncOptions"));
   if (asyncOptions->IsObject()) {
-    v8::Local<v8::Object> asyncOptionsObj = asyncOptions->ToObject();
+    v8::Local<v8::Object> asyncOptionsObj = asyncOptions.As<v8::Object>();
     v8::Local<v8::Value> promisify = asyncOptionsObj->Get(NanNew<v8::String>("promisify"));
     if (!promisify->IsFunction()) {
       return NanTypeError("asyncOptions.promisify must be a function");
@@ -116,8 +116,7 @@ v8::Local<v8::Value> Java::createJVM(JavaVM** jvm, JNIEnv** env) {
     if (!suffix->IsString()) {
       return NanTypeError("asyncOptions.suffix must be a string");
     }
-    v8::Handle<v8::Object> asyncOptionsObjTemp = v8::Handle<v8::Object>::Cast(asyncOptionsObj);
-    NanAssignPersistent(m_asyncOptions, asyncOptionsObjTemp);
+    NanAssignPersistent(m_asyncOptions, asyncOptionsObj);
   }
 
   // setup classpath
@@ -190,6 +189,7 @@ v8::Local<v8::Value> Java::createJVM(JavaVM** jvm, JNIEnv** env) {
   NanObjectWrapHandle(this)->SetAccessor(NanNew<v8::String>("classpath"), AccessorProhibitsOverwritingGetter, AccessorProhibitsOverwritingSetter);
   NanObjectWrapHandle(this)->SetAccessor(NanNew<v8::String>("options"), AccessorProhibitsOverwritingGetter, AccessorProhibitsOverwritingSetter);
   NanObjectWrapHandle(this)->SetAccessor(NanNew<v8::String>("nativeBindingLocation"), AccessorProhibitsOverwritingGetter, AccessorProhibitsOverwritingSetter);
+  NanObjectWrapHandle(this)->SetAccessor(NanNew<v8::String>("asyncOptions"), AccessorProhibitsOverwritingGetter, AccessorProhibitsOverwritingSetter);
 
   return NanNull();
 }
@@ -204,6 +204,8 @@ NAN_GETTER(Java::AccessorProhibitsOverwritingGetter) {
     NanReturnValue(self->m_optionsArray);
   } else if(!strcmp("nativeBindingLocation", *nameStr)) {
     NanReturnValue(NanNew<v8::String>(Java::s_nativeBindingLocation.c_str()));
+  } else if(!strcmp("asyncOptions", *nameStr)) {
+    NanReturnValue(self->m_asyncOptions);
   }
 
   std::ostringstream errStr;

--- a/src/java.h
+++ b/src/java.h
@@ -59,6 +59,7 @@ private:
   static std::string s_nativeBindingLocation;
   v8::Persistent<v8::Array> m_classPathArray;
   v8::Persistent<v8::Array> m_optionsArray;
+  v8::Persistent<v8::Object> m_asyncOptions;
 };
 
 #endif

--- a/src/javaObject.cpp
+++ b/src/javaObject.cpp
@@ -35,7 +35,7 @@
   if(promisifying) {
     v8::Local<v8::Value> promisifyValue = asyncOptions->Get(NanNew<v8::String>("promisify"));
     promisify = promisifyValue.As<v8::Function>();
-    v8::Local<v8::String> suffix = asyncOptions->Get(NanNew<v8::String>("suffix"))->ToString();
+    v8::Local<v8::String> suffix = asyncOptions->Get(NanNew<v8::String>("promiseSuffix"))->ToString();
     v8::String::Utf8Value utf8(suffix);
     promiseSuffix.assign(*utf8);
   }
@@ -73,7 +73,8 @@
         v8::Local<v8::Value> argv[] = { methodCallTemplate->GetFunction() };
         v8::Local<v8::Value> result = promisify->Call(recv, 1, argv);
         if (!result->IsFunction()) {
-          printf("Promisified result is not a function.\n");
+          fprintf(stderr, "Promisified result is not a function -- asyncOptions.promisify must return a function.\n");
+          assert(result->IsFunction());
         }
         v8::Local<v8::Function> promFunction = result.As<v8::Function>();
         v8::Handle<v8::String> methodNamePromise = NanNew<v8::String>((methodNameStr + promiseSuffix).c_str());

--- a/src/javaObject.cpp
+++ b/src/javaObject.cpp
@@ -69,7 +69,7 @@
       funcTemplate->PrototypeTemplate()->Set(methodNameSync, methodCallSyncTemplate->GetFunction());
 
       if (promisifying) {
-        v8::Local<v8::Object> recv = asyncOptions; // just a dummy receiver
+        v8::Local<v8::Object> recv = NanNew<v8::Object>();
         v8::Local<v8::Value> argv[] = { methodCallTemplate->GetFunction() };
         v8::Local<v8::Value> result = promisify->Call(recv, 1, argv);
         if (!result->IsFunction()) {

--- a/src/javaObject.cpp
+++ b/src/javaObject.cpp
@@ -28,7 +28,7 @@
   className = "nodeJava_" + className;
 
   // Set up promisification
-  v8::Local<v8::Object> asyncOptions = NanObjectWrapHandle(java)->Get(NanNew<v8::String>("asyncOptions"))->ToObject();
+  v8::Local<v8::Object> asyncOptions = NanObjectWrapHandle(java)->Get(NanNew<v8::String>("asyncOptions")).As<v8::Object>();
   v8::Local<v8::Function> promisify;
   std::string promiseSuffix;
   bool promisifying = asyncOptions->IsObject();
@@ -76,7 +76,7 @@
           printf("Promisified result is not a function.\n");
         }
         v8::Local<v8::Function> promFunction = result.As<v8::Function>();
-        v8::Handle<v8::String> methodNamePromise = NanNew<v8::String>((methodNameStr + promiseSuffix).c_str());\
+        v8::Handle<v8::String> methodNamePromise = NanNew<v8::String>((methodNameStr + promiseSuffix).c_str());
         funcTemplate->PrototypeTemplate()->Set(methodNamePromise, promFunction);
       }
     }

--- a/src/javaObject.cpp
+++ b/src/javaObject.cpp
@@ -34,7 +34,7 @@
   bool promisifying = asyncOptions->IsObject();
   if(promisifying) {
     v8::Local<v8::Value> promisifyValue = asyncOptions->Get(NanNew<v8::String>("promisify"));
-    promisify = v8::Function::Cast(*promisifyValue);
+    promisify = promisifyValue.As<v8::Function>();
     v8::Local<v8::String> suffix = asyncOptions->Get(NanNew<v8::String>("suffix"))->ToString();
     v8::String::Utf8Value utf8(suffix);
     promiseSuffix.assign(*utf8);
@@ -75,7 +75,7 @@
         if (!result->IsFunction()) {
           printf("Promisified result is not a function.\n");
         }
-        v8::Local<v8::Function> promFunction = v8::Function::Cast(*result);
+        v8::Local<v8::Function> promFunction = result.As<v8::Function>();
         v8::Handle<v8::String> methodNamePromise = NanNew<v8::String>((methodNameStr + promiseSuffix).c_str());\
         funcTemplate->PrototypeTemplate()->Set(methodNamePromise, promFunction);
       }

--- a/test/promises-test.js
+++ b/test/promises-test.js
@@ -126,6 +126,71 @@ exports['Promises'] = nodeunit.testCase({
         test.expect(12);
         test.done();
       });
+  },
+
+  "test when argument promise resolution": function (test) {
+    var when = require('when');
+    var list;
+    var it;
+    java.newInstancePromise("java.util.ArrayList")
+      .then(function(_list) {
+        test.ok(_list);
+        list = _list;
+        return list.getClassPromise();
+      })
+      .then(function(clazz) {
+        test.ok(clazz);
+        return clazz.getNamePromise();
+      })
+      .then(function(name) {
+        test.equal(name, "java.util.ArrayList");
+      })
+      .then(function() {
+        list.addPromise(when('hello'));   // note: passing a promise argument to a java method!
+      })
+      .then(function() {
+        list.addPromise(when('world'));
+      })
+      .then(function() {
+        list.addPromise(when('boo'));
+      })
+      .then(function() {
+        return list.iteratorPromise();
+      })
+      .then(function(_it) {
+        test.ok(_it);
+        it = _it;
+        return it.nextPromise();
+      })
+      .then(function(val) {
+        test.ok(val);
+        test.equal(val, 'hello');
+        return it.nextPromise();
+      })
+      .then(function(val) {
+        test.ok(val);
+        test.equal(val, 'world');
+        return it.nextPromise();
+      })
+      .then(function(val) {
+        test.ok(val);
+        test.equal(val, 'boo');
+        return it.hasNextPromise();
+      })
+      .catch(function(err) {
+        test.ifError(err);
+      })
+      .then(function(more) {
+        test.equal(more, false);
+        return it.nextPromise();
+      })
+      .catch(function(err) {
+        test.ok(/java\.util\.NoSuchElementException/.test(err.toString()));
+      })
+      .then(function() {
+        test.expect(12);
+        test.done();
+      });
   }
 });
 

--- a/test/promises-test.js
+++ b/test/promises-test.js
@@ -1,0 +1,31 @@
+var java = require("../testHelpers").java;
+
+var nodeunit = require("nodeunit");
+var util = require("util");
+
+exports['Promises'] = nodeunit.testCase({
+  "create an instance of a class and call methods (getClassPromise & getNamePromise)": function(test) {
+    java.newInstance("java.util.ArrayList", function(err, list) {
+      if (err) {
+        console.log(err);
+        return;
+      }
+      test.ok(list);
+      if (list) {
+        list.getClassPromise()
+          .then(function(clazz) { return clazz.getNamePromise(); })
+          .then(function(name) {
+            test.equal(name, "java.util.ArrayList");
+          })
+          .catch(function(err) {
+            test.ifError(err);
+          })
+          .then(function() {
+            test.expect(2);
+            test.done();
+          })
+      }
+    });
+  },
+});
+

--- a/test/promises-test.js
+++ b/test/promises-test.js
@@ -62,6 +62,70 @@ exports['Promises'] = nodeunit.testCase({
         test.expect(3);
         test.done();
       });
+  },
+
+  "run chained promisified methods (of class java.util.ArrayList)": function (test) {
+    var list;
+    var it;
+    java.newInstancePromise("java.util.ArrayList")
+      .then(function(_list) {
+        test.ok(_list);
+        list = _list;
+        return list.getClassPromise();
+      })
+      .then(function(clazz) {
+        test.ok(clazz);
+        return clazz.getNamePromise();
+      })
+      .then(function(name) {
+        test.equal(name, "java.util.ArrayList");
+      })
+      .then(function() {
+        list.addPromise('hello');
+      })
+      .then(function() {
+        list.addPromise('world');
+      })
+      .then(function() {
+        list.addPromise('boo');
+      })
+      .then(function() {
+        return list.iteratorPromise();
+      })
+      .then(function(_it) {
+        test.ok(_it);
+        it = _it;
+        return it.nextPromise();
+      })
+      .then(function(val) {
+        test.ok(val);
+        test.equal(val, 'hello');
+        return it.nextPromise();
+      })
+      .then(function(val) {
+        test.ok(val);
+        test.equal(val, 'world');
+        return it.nextPromise();
+      })
+      .then(function(val) {
+        test.ok(val);
+        test.equal(val, 'boo');
+        return it.hasNextPromise();
+      })
+      .catch(function(err) {
+        test.ifError(err);
+      })
+      .then(function(more) {
+        test.equal(more, false);
+        return it.nextPromise();
+      })
+      .catch(function(err) {
+        test.ok(/java\.util\.NoSuchElementException/.test(err.toString()));
+      })
+      .then(function() {
+        test.expect(12);
+        test.done();
+      });
   }
 });
 

--- a/test/promises-test.js
+++ b/test/promises-test.js
@@ -116,7 +116,7 @@ exports['Promises'] = nodeunit.testCase({
         test.ifError(err);
       })
       .then(function(more) {
-        test.equal(more, false);
+        test.ok(!more);
         return it.nextPromise();
       })
       .catch(function(err) {
@@ -181,7 +181,7 @@ exports['Promises'] = nodeunit.testCase({
         test.ifError(err);
       })
       .then(function(more) {
-        test.equal(more, false);
+        test.ok(!more);
         return it.nextPromise();
       })
       .catch(function(err) {

--- a/test/promises-test.js
+++ b/test/promises-test.js
@@ -3,8 +3,11 @@ var java = require("../testHelpers").java;
 var nodeunit = require("nodeunit");
 var util = require("util");
 
+
 exports['Promises'] = nodeunit.testCase({
+
   "create an instance of a class and call methods (getClassPromise & getNamePromise)": function(test) {
+    // Adapted from a test in simple-test.js
     java.newInstance("java.util.ArrayList", function(err, list) {
       if (err) {
         console.log(err);
@@ -23,9 +26,24 @@ exports['Promises'] = nodeunit.testCase({
           .then(function() {
             test.expect(2);
             test.done();
-          })
+          });
       }
     });
   },
+
+  "import and execute promisified static method": function (test) {
+    var Test = java.import('Test');
+    Test.staticMethodPromise(99)
+      .then(function (result) {
+        test.equals(100, result);
+      })
+      .catch(function (err) {
+        test.ifError(err);
+      })
+      .then(function() {
+        test.expect(1);
+        test.done();
+      });
+  }
 });
 

--- a/test/promises-test.js
+++ b/test/promises-test.js
@@ -3,31 +3,27 @@ var java = require("../testHelpers").java;
 var nodeunit = require("nodeunit");
 var util = require("util");
 
-
 exports['Promises'] = nodeunit.testCase({
-
   "create an instance of a class and call methods (getClassPromise & getNamePromise)": function(test) {
     // Adapted from a test in simple-test.js
     java.newInstance("java.util.ArrayList", function(err, list) {
-      if (err) {
-        console.log(err);
-        return;
-      }
+      test.ifError(err);
       test.ok(list);
-      if (list) {
-        list.getClassPromise()
-          .then(function(clazz) { return clazz.getNamePromise(); })
-          .then(function(name) {
-            test.equal(name, "java.util.ArrayList");
-          })
-          .catch(function(err) {
-            test.ifError(err);
-          })
-          .then(function() {
-            test.expect(2);
-            test.done();
-          });
-      }
+      list.getClassPromise()
+        .then(function(clazz) {
+          test.ok(clazz);
+          return clazz.getNamePromise();
+        })
+        .then(function(name) {
+          test.equal(name, "java.util.ArrayList");
+        })
+        .catch(function(err) {
+          test.ifError(err);
+        })
+        .then(function() {
+          test.expect(4);
+          test.done();
+        });
     });
   },
 
@@ -42,6 +38,28 @@ exports['Promises'] = nodeunit.testCase({
       })
       .then(function() {
         test.expect(1);
+        test.done();
+      });
+  },
+
+  "run promisified method of Java module (newInstancePromise)": function (test) {
+    java.newInstancePromise("java.util.ArrayList")
+      .then(function(list) {
+        test.ok(list);
+        return list.getClassPromise();
+      })
+      .then(function(clazz) {
+        test.ok(clazz);
+        return clazz.getNamePromise();
+      })
+      .then(function(name) {
+        test.equal(name, "java.util.ArrayList");
+      })
+      .catch(function(err) {
+        test.ifError(err);
+      })
+      .then(function() {
+        test.expect(3);
         test.done();
       });
   }

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -8,7 +8,7 @@ java.classpath.push("test/commons-lang3-3.1.jar");
 java.classpath.push("test8/");
 
 java.asyncOptions = {
-  suffix: 'Promise',
+  promiseSuffix: 'Promise',
   promisify: require('when/node').lift
 };
 

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -1,4 +1,3 @@
-
 var java = require("./");
 java.options.push("-Djava.awt.headless=true");
 //java.options.push('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005');
@@ -9,7 +8,19 @@ java.classpath.push("test8/");
 
 java.asyncOptions = {
   promiseSuffix: 'Promise',
-  promisify: require('when/node').lift
+  promisify: require('when/node').lift         // when works with all three node versions
+
+// PASSES in all three node versions: 0.8.28, 0.10.35, 0.11.14
+//   promisify: require('when/node').lift         // when works with all three node versions
+//   promisify: require('promise').denodeify      // promise works with all three node versions
+//   promisify: require('vow-node').promisify     // vow-node works with all three node versions
+
+// PASSES in Node 0.10, 0.11.   (incompatible with Node 0.8).
+//   promisify: require('bluebird').promisify     // bluebird requires node >=0.10
+
+// FAILS:
+//   promisify: require('q').denodeify            // FAILS: Q triggers assertion failure in node_object_wrap.h, line 61
+//   promisify: require('p-promise').denodeify    // FAILS: P-promise does not implement catch().
 };
 
 module.exports.java = java;

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -7,4 +7,9 @@ java.classpath.push("test/");
 java.classpath.push("test/commons-lang3-3.1.jar");
 java.classpath.push("test8/");
 
+java.asyncOptions = {
+  suffix: 'Promise',
+  promisify: require('bluebird').promisify
+};
+
 module.exports.java = java;

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -9,7 +9,7 @@ java.classpath.push("test8/");
 
 java.asyncOptions = {
   suffix: 'Promise',
-  promisify: require('bluebird').promisify
+  promisify: require('when/node').lift
 };
 
 module.exports.java = java;


### PR DESCRIPTION
@joeferner: Hi Joe, I managed to get something working for Issue #180.

This only promisifies the instance methods of the imported java classes, but adding support for static methods and promisifying the Java module itself is probably trivial in comparison.

Please review the changes in java.cpp and javaObject.cpp carefully. This implementation was almost blind trial and error without really trying to understand v8 and NAN. In particular I haven't tried to study how to properly handle garbage collection so I may have made mistakes there.

TODO: 

1) More tests.
2) Promisify static methods of Java classes.
3) Promisify the various async methods of the Java module (newInstance, callMethod, callStaticMethod, etc.)
