### PR TITLE
Request for comment: Bug in arraylist iterator using OpenJDK 1.6

### DIFF
--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -323,7 +323,8 @@ exports['Simple'] = nodeunit.testCase({
     list.addSync('hello');
     var it = list.iteratorSync();
     var val = it.nextSync();
-    test.equal(val, 'hello');
+    console.log(typeof val, val);
+    test.strictEqual(val, 'hello');
     test.done();
   },
 
@@ -336,7 +337,8 @@ exports['Simple'] = nodeunit.testCase({
           test.ifError(err);
           it.next(function(err, val) {
             test.ifError(err);
-            test.equal(val, 'hello');
+            console.log(typeof val, val);
+            test.strictEqual(val, 'hello');
             test.done();
           });
         });

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -316,6 +316,32 @@ exports['Simple'] = nodeunit.testCase({
     test.equal(r[0], 1);
     test.equal(r[1], 2);
     test.done();
+  },
+
+  "ArrayList Iterator (sync)": function (test) {
+    var list = java.newInstanceSync("java.util.ArrayList");
+    list.addSync('hello');
+    var it = list.iteratorSync();
+    var val = it.nextSync();
+    test.equal(val, 'hello');
+    test.done();
+  },
+
+  "ArrayList Iterator (async)": function (test) {
+    var list = java.newInstance("java.util.ArrayList", function(err, list) {
+      test.ifError(err);
+      list.add('hello', function (err) {
+        test.ifError(err);
+        list.iterator(function(err, it) {
+          test.ifError(err);
+          it.next(function(err, val) {
+            test.ifError(err);
+            test.equal(val, 'hello');
+            test.done();
+          });
+        });
+      });
+    });
   }
 });
 


### PR DESCRIPTION
@joeferner This is one problem I have run into while working on promises support. It seems that there has been a latent bug with node-java on OpenJDK 1.6. This bug is demonstrated by calling Iterator.next() on an iterator returned from an ArrayList. A java.lang.InternalError exception is thrown. I coded it up with both Sync calls and Async calls. The async version provides an interesting clue. The async call to next() seems to execute without error, but the callback is called with val undefined. It is then when test.strictEqual(val, 'hello') is called that the exception is thrown.

This bug is not present when using Oracle 1.7 and 1.8 JDKs. We have no interest in support for 1.6, so we won't invest any time in trying to fix this bug. For promises support, I intend to disable affected tests at runtime by checking the system property java.version.