### PR TITLE
Feature/enhance node java async options 90115432

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ jdk:
   - oraclejdk8
   - oraclejdk7
 env:
-  - NODE_VERSION="0.11"
+  - NODE_VERSION="0.12"
   - NODE_VERSION="0.10"
-  - NODE_VERSION="0.8"
 before_install:
   - nvm install $NODE_VERSION
 before_script:

--- a/README.md
+++ b/README.md
@@ -147,16 +147,18 @@ try {
 }
 ```
 
-### Promises
+### AsyncOptions: control over the generation of sync, async & promise method variants.
 
-As of release 0.4.5 it is possible to create async methods that return promises by setting the asyncOptions property of the java object.
+As of release 0.4.5 it became possible to create async methods that return promises by setting the asyncOptions property of the java object. With release 0.4.7 this feature is extended to allow changing the suffix assigned for sync and async method variants, and to further configure this module to optionally omit generation of any of these variants.
 
 Example:
 
 ```javascript
 var java = require("java");
 java.asyncOptions = {
-  promiseSuffix: "Promise",
+  asyncSuffix: undefined,     // Don't generate node-style methods taking callbacks
+  syncSuffix: ""              // Sync methods use the base name(!!)
+  promiseSuffix: "Promise",   // Generate methods returning promises, using the suffix Promise.
   promisify: require("when/node").lift
 };
 java.classpath.push("commons-lang3-3.1.jar");
@@ -170,13 +172,18 @@ java.newInstancePromise("java.util.ArrayList")
     .catch(function(err) { /* handle error */ });
 ```
 
-* If you don't want promise-returning methods, simply leave `java.asyncOptions` unset.
-* Sync and standard async methods are still generated as in previous releases. In the future we may provide the option to disable generation of standard async methods.
-* `asyncOptions.promisify` must be a function that given a node.js style async function as input returns a function that returns a promise that is resolved (or rejected) when the async function has completed. Several Promises/A+ libraries provide such functions, but it may be necessary to provide a wrapper function. See `testHelpers.js` for an example.
-* You are free to choose whatever non-empty `promiseSuffix` you want for the promise-returning methods, but you must specify a value.
-* We've tested with five Promises/A+ implementations. See `testHelpers.js` for more information.
+#### NOTES:
+* If you want the defacto standard behavior, simply don't set java.asyncOptions.
+* If you do provide asyncOptions, be aware that this module will not generate method variants of a given flavor if you don't provide a string value for the corresponding suffix (`asyncSuffix`, `syncSuffix`, `promiseSuffix`). In the example above, the application is configured to omit the method variants using node-style async callback functions.
+* If you provide `asyncOptions.promiseSuffix` then you must also set `asyncOptions.promisify` to a function that *promisifies* a node-style async function. I.e. the provided function must take as input a function whose last argument is a node callback function, and it must return an equivalent promise-returning function. Several Promises/A+ libraries provide such functions, but it may be necessary to provide a wrapper function. See `testHelpers.js` for an example.
+* If you provide `asyncOptions.promisify` then you must provide a *non-empty* string for `asyncOptions.promiseSuffix`.
+* Either (but not both) `asyncSuffix` or `syncSuffix` can be the empty string. If you want the defacto standard behavior for no suffix on async methods, you must provide an empty string for `asyncSuffix`.
+* We've tested promises with five Promises/A+ implementations. See `testHelpers.js` for more information.
 * NOTE: Due to specifics of initialization order, the methods  `java.newInstancePromise`, `java.callMethodPromise`, and `java.callStaticMethodPromise` are not available until some other java method is called. You may need to call some other java method such as `java.import()` to finalize java initialization.
 
+##### Special note about the exported module functions `newInstance`, `callMethod`, and `callStaticMethod`.
+These methods come in both async and sync variants. If you provide the `promisify` and `promiseSuffix` attributes in asyncOptions then you'll also get the Promises/A+ variant for these three functions. However, if you change the defacto
+conventions for the `syncSuffix` (i.e. 'Sync') and/or `asyncSuffix` (i.e. '') it will not affect the naming for these three functions. I.e. no matter what you specify in asyncOptions, the async variants are named `newInstance`, `callMethod`, and `callStaticMethod`, and the sync variants are named `newInstanceSync`, `callMethodSync`, and `callStaticMethodSync`.
 
 # Release Notes
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "when": "3.6.4"
   },
   "scripts": {
-    "test": "nodeunit test test8",
+    "test": "node testRunner.js",
     "postinstall": "node postInstall.js"
   },
   "main": "./index.js"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "async": "0.9.0",
     "chalk": "^1.0.0",
+    "lodash": "^3.5.0",
     "nodeunit": "0.9.0",
     "when": "3.6.4"
   },

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "nan": "1.4.1"
   },
   "devDependencies": {
-    "async": "~0.1.22",
+    "async": "0.9.0",
+    "chalk": "^1.0.0",
     "nodeunit": "0.9.0",
-    "when": "~3.6.4"
+    "when": "3.6.4"
   },
   "scripts": {
     "test": "nodeunit test test8",

--- a/src/java.h
+++ b/src/java.h
@@ -21,11 +21,20 @@ public:
   JNIEnv* getJavaEnv() { return m_env; } // can only be used safely by the main thread as this is the thread it belongs to
   jobject getClassLoader() { return m_classLoader; }
 
+public:
+  bool DoSync() const { return doSync; }
+  bool DoAsync() const { return doAsync; }
+  bool DoPromise() const { return doPromise; }
+  std::string SyncSuffix() const { return m_SyncSuffix; }
+  std::string AsyncSuffix() const { return m_AsyncSuffix; }
+  std::string PromiseSuffix() const { return m_PromiseSuffix; }
+
 private:
   Java();
   ~Java();
   v8::Local<v8::Value> createJVM(JavaVM** jvm, JNIEnv** env);
   void destroyJVM(JavaVM** jvm, JNIEnv** env);
+  void configureAsync(v8::Local<v8::Value>& asyncOptions);
 
   static NAN_METHOD(New);
   static NAN_METHOD(getClassLoader);
@@ -60,6 +69,14 @@ private:
   v8::Persistent<v8::Array> m_classPathArray;
   v8::Persistent<v8::Array> m_optionsArray;
   v8::Persistent<v8::Object> m_asyncOptions;
+
+  std::string m_SyncSuffix;
+  std::string m_AsyncSuffix;
+  std::string m_PromiseSuffix;
+
+  bool doSync;
+  bool doAsync;
+  bool doPromise;
 };
 
 #endif

--- a/testAsyncOptions/testAllThreeSuffix.js
+++ b/testAsyncOptions/testAllThreeSuffix.js
@@ -1,0 +1,67 @@
+// testAllThreeSuffix.js
+
+// All three variants have non-empty suffix, i.e a suffix is required for any variant.
+
+var java = require("../");
+var assert = require("assert");
+var _ = require('lodash');
+
+java.asyncOptions = {
+  syncSuffix: "Sync",
+  asyncSuffix: "Async",
+  promiseSuffix: 'Promise',
+  promisify: require('when/node').lift         // https://github.com/cujojs/when
+};
+
+module.exports = {
+  testAPI: function(test) {
+    test.expect(6);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    test.ok(arrayList);
+    test.ok(java.instanceOf(arrayList, "java.util.ArrayList"));
+
+    var api = _.functions(arrayList);
+    test.ok(_.includes(api, 'addSync'), 'Expected `addSync` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'addAsync'), 'Expected `addAsync` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'addPromise'), 'Expected addPromise to be present, but it is NOT.');
+    test.ok(!_.includes(api, 'add'), 'Expected add to NOT be present, but it is.');
+    test.done();
+  },
+
+  testSyncCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addSync("hello");
+    arrayList.addSync("world");
+    test.strictEqual(arrayList.sizeSync(), 2);
+    test.done();
+  },
+
+  testAsyncCalls: function(test) {
+    test.expect(4);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addAsync("hello", function(err, result) {
+      test.ifError(err);
+      arrayList.addAsync("world", function(err, result) {
+        test.ifError(err);
+        arrayList.sizeAsync(function(err, size) {
+          test.ifError(err);
+          test.strictEqual(size, 2);
+          test.done();
+        });
+      });
+    });
+  },
+
+  testPromiseCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addPromise("hello")
+      .then(function () { return arrayList.addPromise("world"); })
+      .then(function () { return arrayList.sizePromise(); })
+      .then(function (size) {
+        test.strictEqual(size, 2);
+        test.done();
+      });
+  }
+}

--- a/testAsyncOptions/testAsyncSuffixSyncDefault.js
+++ b/testAsyncOptions/testAsyncSuffixSyncDefault.js
@@ -1,0 +1,52 @@
+// testAsyncSuffixSyncDefault.js
+
+// Use "Async" for the asyncSuffix, and "" for the syncSuffix.
+
+var java = require("../");
+var assert = require("assert");
+var _ = require('lodash');
+
+java.asyncOptions = {
+  syncSuffix: "",
+  asyncSuffix: "Async"
+};
+
+module.exports = {
+  testAPI: function(test) {
+    test.expect(5);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    test.ok(arrayList);
+    test.ok(java.instanceOf(arrayList, "java.util.ArrayList"));
+
+    var api = _.functions(arrayList);
+    test.ok(_.includes(api, 'addAsync'), 'Expected `addAsync` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'add'), 'Expected `add` to be present, but it is NOT.');
+    test.ok(!_.includes(api, 'addPromise'), 'Expected addPromise to NOT be present, but it is.');
+    test.done();
+  },
+
+  testSyncCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.add("hello");
+    arrayList.add("world");
+    test.strictEqual(arrayList.size(), 2);
+    test.done();
+  },
+
+  testAsyncCalls: function(test) {
+    test.expect(4);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addAsync("hello", function(err, result) {
+      test.ifError(err);
+      arrayList.addAsync("world", function(err, result) {
+        test.ifError(err);
+        arrayList.sizeAsync(function(err, size) {
+          test.ifError(err);
+          test.strictEqual(size, 2);
+          test.done();
+        });
+      });
+    });
+  }
+}

--- a/testAsyncOptions/testDefacto.js
+++ b/testAsyncOptions/testDefacto.js
@@ -1,0 +1,52 @@
+// testDefacto.js
+
+// In the defacto case, the developer sets asyncOptions, but specifies the defacto standard behavior.
+
+var _ = require('lodash');
+var java = require("../");
+var nodeunit = require("nodeunit");
+
+java.asyncOptions = {
+  syncSuffix: "Sync",
+  asyncSuffix: ""
+};
+
+module.exports = {
+  testAPI: function(test) {
+    test.expect(5);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    test.ok(arrayList);
+    test.ok(java.instanceOf(arrayList, "java.util.ArrayList"));
+
+    var api = _.functions(arrayList);
+    test.ok(_.includes(api, 'addSync'), 'Expected `addSync` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'add'), 'Expected `add` to be present, but it is NOT.');
+    test.ok(!_.includes(api, 'addPromise'), 'Expected addPromise to NOT be present, but it is.');
+    test.done();
+  },
+
+  testSyncCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addSync("hello");
+    arrayList.addSync("world");
+    test.strictEqual(arrayList.sizeSync(), 2);
+    test.done();
+  },
+
+  testAsyncCalls: function(test) {
+    test.expect(4);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.add("hello", function(err, result) {
+      test.ifError(err);
+      arrayList.add("world", function(err, result) {
+        test.ifError(err);
+        arrayList.size(function(err, size) {
+          test.ifError(err);
+          test.strictEqual(size, 2);
+          test.done();
+        });
+      });
+    });
+  }
+}

--- a/testAsyncOptions/testDefactoPlusPromise.js
+++ b/testAsyncOptions/testDefactoPlusPromise.js
@@ -1,0 +1,66 @@
+// testDefactoPlusPromise.js
+
+// The defacto case but with promises also enabled.
+
+var java = require("../");
+var assert = require("assert");
+var _ = require('lodash');
+
+java.asyncOptions = {
+  syncSuffix: "Sync",
+  asyncSuffix: "",
+  promiseSuffix: 'Promise',
+  promisify: require('when/node').lift         // https://github.com/cujojs/when
+};
+
+module.exports = {
+  testAPI: function(test) {
+    test.expect(5);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    test.ok(arrayList);
+    test.ok(java.instanceOf(arrayList, "java.util.ArrayList"));
+
+    var api = _.functions(arrayList);
+    test.ok(_.includes(api, 'addSync'), 'Expected `addSync` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'add'), 'Expected `add` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'addPromise'), 'Expected `addPromise` to be present, but it is NOT.');
+    test.done();
+  },
+
+  testSyncCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addSync("hello");
+    arrayList.addSync("world");
+    test.strictEqual(arrayList.sizeSync(), 2);
+    test.done();
+  },
+
+  testAsyncCalls: function(test) {
+    test.expect(4);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.add("hello", function(err, result) {
+      test.ifError(err);
+      arrayList.add("world", function(err, result) {
+        test.ifError(err);
+        arrayList.size(function(err, size) {
+          test.ifError(err);
+          test.strictEqual(size, 2);
+          test.done();
+        });
+      });
+    });
+  },
+
+  testPromiseCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addPromise("hello")
+      .then(function () { return arrayList.addPromise("world"); })
+      .then(function () { return arrayList.sizePromise(); })
+      .then(function (size) {
+        test.strictEqual(size, 2);
+        test.done();
+      });
+  }
+}

--- a/testAsyncOptions/testDefault.js
+++ b/testAsyncOptions/testDefault.js
@@ -1,0 +1,50 @@
+// testDefault.js
+
+// In the default case, the developer does not set asyncOptions.
+// We should get the defacto standard behavior.
+
+var _ = require('lodash');
+var java = require("../");
+var nodeunit = require("nodeunit");
+
+java.asyncOptions = undefined;
+
+module.exports = {
+  testAPI: function(test) {
+    test.expect(5);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    test.ok(arrayList);
+    test.ok(java.instanceOf(arrayList, "java.util.ArrayList"));
+
+    var api = _.functions(arrayList);
+    test.ok(_.includes(api, 'addSync'), 'Expected `addSync` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'add'), 'Expected `add` to be present, but it is NOT.');
+    test.ok(!_.includes(api, 'addPromise'), 'Expected addPromise to NOT be present, but it is.');
+    test.done();
+  },
+
+  testSyncCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addSync("hello");
+    arrayList.addSync("world");
+    test.strictEqual(arrayList.sizeSync(), 2);
+    test.done();
+  },
+
+  testAsyncCalls: function(test) {
+    test.expect(4);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.add("hello", function(err, result) {
+      test.ifError(err);
+      arrayList.add("world", function(err, result) {
+        test.ifError(err);
+        arrayList.size(function(err, size) {
+          test.ifError(err);
+          test.strictEqual(size, 2);
+          test.done();
+        });
+      });
+    });
+  }
+}

--- a/testAsyncOptions/testNoAsync.js
+++ b/testAsyncOptions/testNoAsync.js
@@ -1,0 +1,50 @@
+// testNoAsync.js
+
+// Just Sync and Promise, both with a non-empty suffix.
+
+var java = require("../");
+var assert = require("assert");
+var _ = require('lodash');
+
+java.asyncOptions = {
+  syncSuffix: "Sync",
+  promiseSuffix: 'Promise',
+  promisify: require('when/node').lift         // https://github.com/cujojs/when
+};
+
+module.exports = {
+  testAPI: function(test) {
+    test.expect(6);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    test.ok(arrayList);
+    test.ok(java.instanceOf(arrayList, "java.util.ArrayList"));
+
+    var api = _.functions(arrayList);
+    test.ok(_.includes(api, 'addSync'), 'Expected `addSync` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'addPromise'), 'Expected `addPromise` to be present, but it is NOT.');
+    test.ok(!_.includes(api, 'add'), 'Expected `add` to NOT be present, but it is.');
+    test.ok(!_.includes(api, 'addAsync'), 'Expected `addAsync` to NOT be present, but it is.');
+    test.done();
+  },
+
+  testSyncCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addSync("hello");
+    arrayList.addSync("world");
+    test.strictEqual(arrayList.sizeSync(), 2);
+    test.done();
+  },
+
+  testPromiseCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addPromise("hello")
+      .then(function () { return arrayList.addPromise("world"); })
+      .then(function () { return arrayList.sizePromise(); })
+      .then(function (size) {
+        test.strictEqual(size, 2);
+        test.done();
+      });
+  }
+}

--- a/testAsyncOptions/testSyncDefaultPlusPromise.js
+++ b/testAsyncOptions/testSyncDefaultPlusPromise.js
@@ -1,0 +1,51 @@
+// testSyncDefaultPlusPromise.js
+
+// Just Sync and Promise, with Sync the default (i.e. no suffix).
+// This is the configuration that RedSeal wants for use with Tinkerpop/Gremlin.
+
+var java = require("../");
+var assert = require("assert");
+var _ = require('lodash');
+
+java.asyncOptions = {
+  syncSuffix: "",
+  promiseSuffix: 'P',
+  promisify: require('when/node').lift         // https://github.com/cujojs/when
+};
+
+module.exports = {
+  testAPI: function(test) {
+    test.expect(6);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    test.ok(arrayList);
+    test.ok(java.instanceOf(arrayList, "java.util.ArrayList"));
+
+    var api = _.functions(arrayList);
+    test.ok(_.includes(api, 'add'), 'Expected `add` to be present, but it is NOT.');
+    test.ok(_.includes(api, 'addP'), 'Expected `addP` to be present, but it is NOT.');
+    test.ok(!_.includes(api, 'addSync'), 'Expected `addSync` to NOT be present, but it is.');
+    test.ok(!_.includes(api, 'addAsync'), 'Expected `addAsync` to NOT be present, but it is.');
+    test.done();
+  },
+
+  testSyncCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.add("hello");
+    arrayList.add("world");
+    test.strictEqual(arrayList.size(), 2);
+    test.done();
+  },
+
+  testPromiseCalls: function(test) {
+    test.expect(1);
+    var arrayList = java.newInstanceSync("java.util.ArrayList");
+    arrayList.addP("hello")
+      .then(function () { return arrayList.addP("world"); })
+      .then(function () { return arrayList.sizeP(); })
+      .then(function (size) {
+        test.strictEqual(size, 2);
+        test.done();
+      });
+  }
+}

--- a/testHelpers.js
+++ b/testHelpers.js
@@ -15,8 +15,11 @@ function promisifyQ(f) {
 }
 
 java.asyncOptions = {
+  syncSuffix: "Sync",
+  asyncSuffix: "",
   promiseSuffix: 'Promise',
   promisify: require('when/node').lift         // https://github.com/cujojs/when
+
 
 // We've tested with 5 different Promises/A+ implementations:
 //   promisify: require('bluebird').promisify     // https://github.com/petkaantonov/bluebird/

--- a/testRunner.js
+++ b/testRunner.js
@@ -1,0 +1,35 @@
+// testRunner.js
+
+// This is a custom test runner. All tests are run with nodeunit, but in separate
+// processes, which allows us to test java with different configuration options.
+
+var async = require('async');
+var chalk = require('chalk');
+var childProcess = require('child_process');
+var glob = require('glob');
+var path = require('path');
+
+var tests = glob.sync(path.join('testAsyncOptions', '*.js'));
+
+tests.unshift('test test8');  // Arrange to run the primary tests first, in a single process
+
+function runTest(testArgs, done) {
+  var cmd = 'node_modules/.bin/nodeunit ' + testArgs;
+  childProcess.exec(cmd, function (error, stdout, stderr) {
+    // It appears that nodeunit merges error output into the stdout
+    // so these three lines are probably useless.
+    var errText = stderr.toString();
+    if (errText !== '')
+      console.error(chalk.bold.red(errText));
+
+    process.stdout.write(stdout.toString());
+    done(error);
+  });
+}
+
+async.eachSeries(tests, runTest, function(err) {
+  if (err) {
+    console.error(chalk.bold.red(err));
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
This PR extends the asyncOptions/Promises feature I added previously in PR #187 and PR #189.

It is now possible to specify the suffix that should be used for the Sync and Async variants, or to disable the generation of either of them. See the tests in the testAsyncOptions directory for examples.

Note that while in the previous PRs for promises I arranged to promisify three of the exported functions of the java module (`newInstance`, `callMethod`, `callStaticMethod`), this feature as currently implemented does not allow changing the names of the sync and async variants of those functions, due to complications with order of initialization. I'm currently just documenting this inconsistency.

Note also that this branch changes the `npm test` command to use a test runner. I'm open to suggestions for a better approach.

to: @joeferner 
cc: @mhfrantz @jsdevel 