### PR TITLE
Change Travis to build against node 0.10 and 0.12. Drop 0.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ jdk:
   - oraclejdk8
   - oraclejdk7
 env:
-  - NODE_VERSION="0.11"
+  - NODE_VERSION="0.12"
   - NODE_VERSION="0.10"
-  - NODE_VERSION="0.8"
 before_install:
   - nvm install $NODE_VERSION
 before_script:


### PR DESCRIPTION
@joeferner What do you think? Ok to drop node 0.8 and 0.11, and just build node 0.10 and 0.12?
