### PR TITLE
Add the registerClient/ensureJvm API

### DIFF
--- a/lib/nodeJavaBridge.js
+++ b/lib/nodeJavaBridge.js
@@ -2,6 +2,8 @@
 
 process.env.PATH += require('../build/jvm_dll_path.json');
 
+var _ = require('lodash');
+var async = require('async');
 var path = require('path');
 var fs = require('fs');
 var binaryPath = path.resolve(path.join(__dirname, "../build/Release/nodejavabridge_bindings.node"));
@@ -28,6 +30,125 @@ var SyncCall = function(obj, method) {
     return obj[syncMethodName].bind(obj);
   else
     throw new Error('Sync method not found:' + syncMethodName);
+}
+
+java.isJvmCreated = function() {
+  return typeof java.onJvmCreated !== 'function';
+}
+
+var clients = [];
+
+// We provide two methods for 'clients' of node-java to 'register' their use of java.
+// By registering, a client gets the opportunity to be called asynchronously just before the JVM is created,
+// and just after the JVM is created. The before hook function will typically be used to add to java.classpath.
+// The function may peform asynchronous operations, such as async [glob](https://github.com/isaacs/node-glob)
+// resolutions of wild-carded file system paths, and then notify when it has finished via either calling
+// a node-style callback function, or by resolving a promise.
+
+// A client can register function hooks to be called before and after the JVM is created.
+// If the client doesn't need to be called back for either function, it can pass null or undefined.
+// Both before and after here are assumed to be functions that accept one argument that is a node-callback function.
+java.registerClient = function(before, after) {
+  if (java.isJvmCreated()) {
+    throw new Error('java.registerClient() called after JVM already created.');
+  }
+  clients.push({before: before, after: after});
+}
+
+// A client can register function hooks to be called before and after the JVM is created.
+// If the client doesn't need to be called back for either function, it can pass null or undefined.
+// Both before and after here are assumed to be functions that return Promises/A+ `thenable` objects.
+java.registerClientP = function(beforeP, afterP) {
+  if (java.isJvmCreated()) {
+    throw new Error('java.registerClient() called after JVM already created.');
+  }
+  clients.push({beforeP: beforeP, afterP: afterP});
+}
+
+function runBeforeHooks(done) {
+  function iterator(client, cb) {
+    try {
+      if (client.before) {
+        client.before(cb);
+      }
+      else if (client.beforeP) {
+        client.beforeP().then(function(ignored) { cb(); }, function(err) { cb(err); });
+      }
+      else {
+        cb();
+      }
+    }
+    catch (err) {
+      cb(err);
+    }
+  }
+  async.each(clients, iterator, done);
+}
+
+function createJVMAsync(callback) {
+  var ignore = java.newLong(0); // called just for the side effect that it will create the JVM
+  callback();
+}
+
+function runAfterHooks(done) {
+  function iterator(client, cb) {
+    try {
+      if (client.after) {
+        client.after(cb);
+      }
+      else if (client.afterP) {
+        client.afterP().then(function(ignored) { cb(); }, function(err) { cb(err); });
+      }
+      else {
+        cb();
+      }
+    }
+    catch (err) {
+      cb(err);
+    }
+  }
+  async.each(clients, iterator, done);
+}
+
+function initializeAll(done) {
+  async.series([runBeforeHooks, createJVMAsync, runAfterHooks], done);
+}
+
+// This function ensures that the JVM has been launched, asynchronously. The application can be notified
+// when the JVM is fully created via either a node callback function, or via a promise.
+// If the parameter `callback` is provided, it is assume be a node callback function.
+// If the parameter is not provided, and java.asyncOptions.promisify has been specified,
+// then this function will return a promise, by promisifying itself and then calling that
+// promisified function.
+// This function may be called multiple times -- the 2nd and subsequent calls are no-ops.
+// However, once this method has been called (or the JVM is launched as a side effect of calling other java
+// methods), then clients can no longer use the registerClient API.
+java.ensureJvm = function(callback) {
+
+  // First see if the promise-style API should be used.
+  // This must be done first in order to ensure the proper API is used.
+  if (_.isUndefined(callback) && java.asyncOptions && _.isFunction(java.asyncOptions.promisify)) {
+    // Create a promisified version of this function.
+    var launchJvmPromise = java.asyncOptions.promisify(java.ensureJvm.bind(java));
+    // Call the promisified function, returning its result, which should be a promise.
+    return launchJvmPromise();
+  }
+
+  // If we get here, callback must be a node-style callback function. If not, throw an error.
+  else if (!_.isFunction(callback)) {
+    throw new Error('java.launchJvm(cb) requires its one argument to be a callback function.');
+  }
+
+  // Now check if the JVM has already been created. If so, we assume that the jvm was already successfully
+  // launched, and we can just implement idempotent behavior, i.e. silently notify that the JVM has been created.
+  else if (java.isJvmCreated()) {
+    return setImmediate(callback);
+  }
+
+  // Finally, queue the initializeAll function.
+  else {
+    return setImmediate(initializeAll, callback);
+  }
 }
 
 java.onJvmCreated = function() {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "url": "https://github.com/joeferner/node-java.git"
   },
   "dependencies": {
+    "async": "0.9.0",
     "find-java-home": "0.1.2",
     "glob": "5.0.5",
     "nan": "1.7.0"
   },
   "devDependencies": {
-    "async": "0.9.0",
     "chalk": "1.0.0",
     "lodash": "3.7.0",
     "nodeunit": "0.9.1",

--- a/testAsyncOptions/testClientBeforeError.js
+++ b/testAsyncOptions/testClientBeforeError.js
@@ -1,0 +1,33 @@
+// testClientBeforeError.js
+
+var _ = require('lodash');
+var java = require("../");
+var nodeunit = require("nodeunit");
+
+module.exports = {
+
+  clientBeforeError: function(test) {
+    test.expect(6);
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "Sync",
+    };
+
+    function before(callback) {
+      test.ok(!java.isJvmCreated());
+      callback(new Error('dummy error'));
+    }
+
+    java.registerClient(before);
+
+    java.ensureJvm(function(err) {
+      test.ok(_.isObject(err));
+      test.ok(err instanceof Error);
+      test.strictEqual(err.message, 'dummy error');
+      test.ok(!java.isJvmCreated());
+      test.done();
+    });
+  }
+
+}

--- a/testAsyncOptions/testClientBeforeThrows.js
+++ b/testAsyncOptions/testClientBeforeThrows.js
@@ -1,0 +1,33 @@
+// testClientBeforeThrows.js
+
+var _ = require('lodash');
+var java = require("../");
+var nodeunit = require("nodeunit");
+
+module.exports = {
+
+  clientBeforeThrows: function(test) {
+    test.expect(6);
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "Sync",
+    };
+
+    function before(callback) {
+      test.ok(!java.isJvmCreated());
+      throw new Error('dummy error');
+    }
+
+    java.registerClient(before);
+
+    java.ensureJvm(function(err) {
+      test.ok(_.isObject(err));
+      test.ok(err instanceof Error);
+      test.strictEqual(err.message, 'dummy error');
+      test.ok(!java.isJvmCreated());
+      test.done();
+    });
+  }
+
+}

--- a/testAsyncOptions/testClientPBeforeError.js
+++ b/testAsyncOptions/testClientPBeforeError.js
@@ -1,0 +1,44 @@
+// testClientPBeforeError.js
+
+var _ = require('lodash');
+var java = require("../");
+var nodeunit = require("nodeunit");
+var when = require('when');
+
+module.exports = {
+
+  clientPBeforeError: function(test) {
+    test.expect(6);
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "Sync",
+      promiseSuffix: 'Promise',
+      promisify: require('when/node').lift         // https://github.com/cujojs/when
+    };
+
+    function beforeP() {
+      var promise = when.promise(function(resolve, reject) {
+        test.ok(!java.isJvmCreated());
+        reject(new Error('dummy error'));
+      });
+      return promise;
+    }
+
+    java.registerClientP(beforeP);
+
+    java.ensureJvm().done(
+      function () {
+        test.ok(false);
+      },
+      function(err) {
+        test.ok(_.isObject(err));
+        test.ok(err instanceof Error);
+        test.strictEqual(err.message, 'dummy error');
+        test.ok(!java.isJvmCreated());
+        test.done();
+      }
+    );
+  }
+
+}

--- a/testAsyncOptions/testClientPBeforeThrows.js
+++ b/testAsyncOptions/testClientPBeforeThrows.js
@@ -1,0 +1,44 @@
+// testClientPBeforeThrows.js
+
+var _ = require('lodash');
+var java = require("../");
+var nodeunit = require("nodeunit");
+var when = require('when');
+
+module.exports = {
+
+  clientPBeforeThrows: function(test) {
+    test.expect(6);
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "Sync",
+      promiseSuffix: 'Promise',
+      promisify: require('when/node').lift         // https://github.com/cujojs/when
+    };
+
+    function beforeP() {
+      var promise = when.promise(function(resolve, reject) {
+        test.ok(!java.isJvmCreated());
+        throw new Error('dummy error');
+      });
+      return promise;
+    }
+
+    java.registerClientP(beforeP);
+
+    java.ensureJvm().done(
+      function () {
+        test.ok(false);
+      },
+      function(err) {
+        test.ok(_.isObject(err));
+        test.ok(err instanceof Error);
+        test.strictEqual(err.message, 'dummy error');
+        test.ok(!java.isJvmCreated());
+        test.done();
+      }
+    );
+  }
+
+}

--- a/testAsyncOptions/testDefacto.js
+++ b/testAsyncOptions/testDefacto.js
@@ -6,12 +6,45 @@ var _ = require('lodash');
 var java = require("../");
 var nodeunit = require("nodeunit");
 
-java.asyncOptions = {
-  syncSuffix: "Sync",
-  asyncSuffix: ""
-};
-
 module.exports = {
+
+  launch: function(test) {
+    test.expect(9);
+    var api = _.functions(java);
+    test.ok(_.includes(api, 'isJvmCreated'), 'Expected `isJvmCreated` to be present, but it is NOT.');
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "Sync",
+      asyncSuffix: ""
+    };
+
+    function before(callback) {
+      test.ok(!java.isJvmCreated());
+      callback();
+    }
+
+    function after(callback) {
+      test.ok(java.isJvmCreated());
+      callback();
+    }
+
+    java.registerClient(before, after);
+    java.registerClient(undefined, after);
+    java.registerClient(before, undefined);
+
+    java.ensureJvm(function(err) {
+      test.ifError(err);
+      test.ok(java.isJvmCreated());
+
+      // Verify that ensureJvm is idempotent
+      java.ensureJvm(function(err) {
+        test.ifError(err);
+        test.done();
+      });
+    });
+  },
+
   testAPI: function(test) {
     test.expect(5);
     var arrayList = java.newInstanceSync("java.util.ArrayList");

--- a/testAsyncOptions/testDefactoPlusPromise.js
+++ b/testAsyncOptions/testDefactoPlusPromise.js
@@ -4,16 +4,42 @@
 
 var java = require("../");
 var assert = require("assert");
-var _ = require('lodash');
-
-java.asyncOptions = {
-  syncSuffix: "Sync",
-  asyncSuffix: "",
-  promiseSuffix: 'Promise',
-  promisify: require('when/node').lift         // https://github.com/cujojs/when
-};
+var _ = require("lodash");
 
 module.exports = {
+  launch: function(test) {
+    test.expect(7);
+    var api = _.functions(java);
+    test.ok(_.includes(api, 'isJvmCreated'), 'Expected `isJvmCreated` to be present, but it is NOT.');
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "Sync",
+      asyncSuffix: "",
+      promiseSuffix: 'Promise',
+      promisify: require('when/node').lift         // https://github.com/cujojs/when
+    };
+
+    function before(callback) {
+      test.ok(!java.isJvmCreated());
+      callback();
+    }
+
+    function after(callback) {
+      test.ok(java.isJvmCreated());
+      callback();
+    }
+
+    java.registerClient(before, after);
+    java.registerClient(null, after);
+    java.registerClient(before);
+
+    java.ensureJvm().done(function() {
+      test.ok(java.isJvmCreated());
+      test.done();
+    });
+  },
+
   testAPI: function(test) {
     test.expect(5);
     var arrayList = java.newInstanceSync("java.util.ArrayList");

--- a/testAsyncOptions/testInvalidLaunch.js
+++ b/testAsyncOptions/testInvalidLaunch.js
@@ -1,0 +1,59 @@
+// testInvalidLaunch.js
+
+var _ = require('lodash');
+var java = require("../");
+var nodeunit = require("nodeunit");
+
+module.exports = {
+
+  failedLaunch: function(test) {
+    test.expect(3);
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "Sync",
+      asyncSuffix: ""
+    };
+
+    // First show that if asyncOptions.promisify is undefined, using the promise variant of ensureJvm throws an error.
+    test.throws(function() { java.ensureJvm(); }, Error, /requires its one argument to be a callback function/);
+
+    test.ok(!java.isJvmCreated());
+    test.done();
+  },
+
+  callbackNotAFunction: function(test) {
+    test.expect(3);
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "",
+      promiseSuffix: 'P',
+      promisify: require('when/node').lift         // https://github.com/cujojs/when
+    };
+
+    test.throws(function() { java.ensureJvm('foo'); }, Error, /requires its one argument to be a callback function/);
+
+    test.ok(!java.isJvmCreated());
+    test.done();
+  },
+
+  jvmCanStillBeLaunched: function(test) {
+    // None of the previous tests should have caused the JVM to be created, so it should still be possible to create one.
+
+    test.expect(2);
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "",
+      promiseSuffix: 'P',
+      promisify: require('when/node').lift         // https://github.com/cujojs/when
+    };
+
+    java.ensureJvm().done(function() {
+      test.ok(java.isJvmCreated());
+      test.done();
+    });
+  }
+
+}


### PR DESCRIPTION
@joeferner This is a new API that we have found useful. It makes it simpler to have several semi-independent modules that encapsulate specific Java classes or libraries, and then compose these modules into a larger application.