### PR TITLE
Remove call to JNI_GetDefaultJavaVMInitArgs

### DIFF
--- a/src/java.cpp
+++ b/src/java.cpp
@@ -249,6 +249,8 @@ v8::Local<v8::Value> Java::createJVM(JavaVM** jvm, JNIEnv** env) {
   JNI_CreateJavaVM(&jvmTemp, (void **)env, &args);
   *jvm = jvmTemp;
 
+  delete [] vmOptions;
+
   m_classLoader = getSystemClassLoader(*env);
 
   v8::Local<v8::Value> onJvmCreated = NanObjectWrapHandle(this)->Get(NanNew<v8::String>("onJvmCreated"));


### PR DESCRIPTION
@joeferner @jsdevel 

This change was prompted by #230, and the error message contained there stating that `warning: 'JNI_GetDefaultJavaVMInitArgs' is deprecated`. It's not clear to me exactly which platforms deprecate the call, but it does seem pretty clear that Oracle has considered the call unnecessary at least since Java 6. I figure we might as well remove it and see if it causes any problems on obscure platforms (but note, for me, all variants of MS Windows are obscure.)

I could just merge this but wanted to give you a both chance to stop this PR if you have relevant knowledge about JNI_GetDefaultJavaVMInitArgs on obscure platforms.

While researching it I also noticed and fixed a memory leak.