### PR TITLE
Use of node-pre-gyp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node-java.cbp
 *.iml
 *.kdev4
 */.kdev_include_paths
+lib/jvm_dll_path.json

--- a/binding.gyp
+++ b/binding.gyp
@@ -162,6 +162,17 @@
           },
         ],
       ]
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "destination": "<(module_path)"
+        }
+      ]
     }
   ]
 }

--- a/install.js
+++ b/install.js
@@ -1,11 +1,81 @@
 var pregyp = require('node-pre-gyp');
+var glob = require('glob');
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
 
-console.log('Setting environment path for JVM DLL');
-process.env.PATH += require('./build/jvm_dll_path.json');
+require('find-java-home')(function(err, home){
+    var dll;
+    var dylib;
+    var so,soFiles;
+    var binary;
 
-var pregypRun = new pregyp.Run();
-pregypRun.parseArgv([ '--fallback-to-build' ]);
+    if(home){
+        dll = glob.sync('**/jvm.dll', {cwd: home})[0];
+        dylib = glob.sync('**/libjvm.dylib', {cwd: home})[0];
+        soFiles = glob.sync('**/libjvm.so', {cwd: home});
 
-pregypRun.commands.install(pregypRun, function() {
-    console.log('Done installing with node-pre-gyp');
+        if(soFiles.length>0)
+            so = getCorrectSoForPlatform(soFiles);
+
+        binary = dll || dylib || so;
+
+        fs.writeFileSync(
+            path.resolve(__dirname, './build/jvm_dll_path.json'),
+            binary
+                ? JSON.stringify(
+                path.delimiter
+                + path.dirname(path.resolve(home, binary))
+            )
+                : '""'
+        );
+        
+        console.log('Setting environment path for JVM DLL');
+        process.env.PATH += require('./build/jvm_dll_path.json');
+
+        var pregypRun = new pregyp.Run();
+        pregypRun.parseArgv([ '--fallback-to-build' ]);
+
+        pregypRun.commands.install(pregypRun, function() {
+            console.log('Done installing with node-pre-gyp');
+        });
+    }
 });
+
+function getCorrectSoForPlatform(soFiles){
+    var so = _getCorrectSoForPlatform(soFiles);
+    if (so) {
+        so = removeDuplicateJre(so);
+    }
+    return so;
+}
+
+function removeDuplicateJre(filePath){
+    while(filePath.indexOf('jre/jre')>=0){
+        filePath = filePath.replace('jre/jre','jre');
+    }
+    return filePath;
+}
+
+function _getCorrectSoForPlatform(soFiles){
+
+    var architectureFolderNames = {
+        'ia32': 'i386',
+        'x64': 'amd64'
+    };
+
+    if(os.platform() != 'sunos')
+        return soFiles[0];
+
+    var requiredFolderName = architectureFolderNames[os.arch()];
+
+    for (var i = 0; i < soFiles.length; i++) {
+        var so = soFiles[i];
+
+        if(so.indexOf('server')>0)
+            if(so.indexOf(requiredFolderName)>0)
+                return so;
+    }
+
+    return soFiles[0];
+}

--- a/install.js
+++ b/install.js
@@ -10,7 +10,13 @@ require('find-java-home')(function(err, home){
     var so,soFiles;
     var binary;
 
+    if (!home) {
+        console.log('Java home not found. Can\'t continue');
+    }
+
     if(home){
+        console.log('Java home found. Searching for applicable DLLs');
+
         dll = glob.sync('**/jvm.dll', {cwd: home})[0];
         dylib = glob.sync('**/libjvm.dylib', {cwd: home})[0];
         soFiles = glob.sync('**/libjvm.so', {cwd: home});
@@ -20,8 +26,12 @@ require('find-java-home')(function(err, home){
 
         binary = dll || dylib || so;
 
+        var jvmDllPath = path.resolve(__dirname, './build/jvm_dll_path.json');
+
+        console.log('Creating ' + jvmDllPath);
+
         fs.writeFileSync(
-            path.resolve(__dirname, './build/jvm_dll_path.json'),
+            jvmDllPath,
             binary
                 ? JSON.stringify(
                 path.delimiter
@@ -29,7 +39,7 @@ require('find-java-home')(function(err, home){
             )
                 : '""'
         );
-        
+
         console.log('Setting environment path for JVM DLL');
         process.env.PATH += require('./build/jvm_dll_path.json');
 

--- a/install.js
+++ b/install.js
@@ -29,6 +29,10 @@ require('find-java-home')(function(err, home){
         var jvmDllPath = path.resolve(__dirname, './build/jvm_dll_path.json');
         var jvmDllContent = path.delimiter + path.dirname(path.resolve(home, binary));
 
+        if (!fs.existsSync(path.resolve(__dirname, './build'))) {
+            fs.mkdirSync(path.resolve(__dirname, './build'));
+        }
+
         console.log('Creating ' + jvmDllPath);
 
         fs.writeFileSync(

--- a/install.js
+++ b/install.js
@@ -1,0 +1,11 @@
+var pregyp = require('node-pre-gyp');
+
+console.log('Setting environment path for JVM DLL');
+process.env.PATH += require('./build/jvm_dll_path.json');
+
+var pregypRun = new pregyp.Run();
+pregypRun.parseArgv([ '--fallback-to-build' ]);
+
+pregypRun.commands.install(pregypRun, function() {
+    console.log('Done installing with node-pre-gyp');
+});

--- a/install.js
+++ b/install.js
@@ -26,12 +26,8 @@ require('find-java-home')(function(err, home){
 
         binary = dll || dylib || so;
 
-        var jvmDllPath = path.resolve(__dirname, './build/jvm_dll_path.json');
+        var jvmDllPath = path.resolve(__dirname, './lib/jvm_dll_path.json');
         var jvmDllContent = path.delimiter + path.dirname(path.resolve(home, binary));
-
-        if (!fs.existsSync(path.resolve(__dirname, './build'))) {
-            fs.mkdirSync(path.resolve(__dirname, './build'));
-        }
 
         console.log('Creating ' + jvmDllPath);
 

--- a/install.js
+++ b/install.js
@@ -27,21 +27,19 @@ require('find-java-home')(function(err, home){
         binary = dll || dylib || so;
 
         var jvmDllPath = path.resolve(__dirname, './build/jvm_dll_path.json');
+        var jvmDllContent = path.delimiter + path.dirname(path.resolve(home, binary));
 
         console.log('Creating ' + jvmDllPath);
 
         fs.writeFileSync(
             jvmDllPath,
-            binary
-                ? JSON.stringify(
-                path.delimiter
-                + path.dirname(path.resolve(home, binary))
-            )
-                : '""'
+            binary ? JSON.stringify(jvmDllContent) : '""'
         );
 
-        console.log('Setting environment path for JVM DLL');
-        process.env.PATH += require('./build/jvm_dll_path.json');
+        if (binary) {
+            console.log('Setting environment path for JVM DLL');
+            process.env.PATH += jvmDllContent;
+        }
 
         var pregypRun = new pregyp.Run();
         pregypRun.parseArgv([ '--fallback-to-build' ]);

--- a/lib/nodeJavaBridge.js
+++ b/lib/nodeJavaBridge.js
@@ -1,12 +1,12 @@
 'use strict';
 
-process.env.PATH += require('../build/jvm_dll_path.json');
+process.env.PATH += require('../lib/jvm_dll_path.json');
 
 var _ = require('lodash');
 var async = require('async');
 var path = require('path');
 var fs = require('fs');
-var binaryPath = path.resolve(path.join(__dirname, "../build/Release/nodejavabridge_bindings.node"));
+var binaryPath = path.resolve(path.join(__dirname, "../lib/binding/nodejavabridge_bindings.node"));
 var bindings = require(binaryPath);
 
 var java = module.exports = new bindings.Java();

--- a/lib/nodeJavaBridge.js
+++ b/lib/nodeJavaBridge.js
@@ -1,11 +1,12 @@
 'use strict';
 
-process.env.PATH += require('../lib/jvm_dll_path.json');
-
 var _ = require('lodash');
 var async = require('async');
 var path = require('path');
 var fs = require('fs');
+
+process.env.PATH += require('..' + path.sep + 'lib' + path.sep + 'jvm_dll_path.json');
+
 var binaryPath = path.resolve(path.join(__dirname, "../lib/binding/nodejavabridge_bindings.node"));
 var bindings = require(binaryPath);
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "bundledDependencies":["node-pre-gyp"],
   "scripts": {
-    "preinstall": "node postInstall.js",
+    "preinstall": "node install glob; node postInstall.js",
     "install": "node install.js",
     "test": "node testRunner.js"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "bundledDependencies":["node-pre-gyp"],
   "scripts": {
-    "preinstall": "node install glob; node postInstall.js",
+    "preinstall": "npm install glob; node postInstall.js",
     "install": "npm install node-pre-gyp; node install.js",
     "test": "node testRunner.js"
   },

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "bundledDependencies":["node-pre-gyp"],
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
-    "test": "node testRunner.js",
-    "postinstall": "node postInstall.js"
+    "preinstall": "node postInstall.js",
+    "install": "node install.js",
+    "test": "node testRunner.js"
   },
   "main": "./index.js",
   "binary": {

--- a/package.json
+++ b/package.json
@@ -30,16 +30,25 @@
     "find-java-home": "0.1.2",
     "glob": "5.0.5",
     "lodash": "3.7.0",
-    "nan": "1.7.0"
+    "nan": "1.7.0",
+    "node-pre-gyp": "0.5.x"
   },
   "devDependencies": {
     "chalk": "1.0.0",
     "nodeunit": "0.9.1",
-    "when": "3.7.2"
+    "when": "3.7.2",
+    "aws-sdk": "~2.0.0-rc.15"
   },
+  "bundledDependencies":["node-pre-gyp"],
   "scripts": {
+    "install": "node-pre-gyp install --fallback-to-build",
     "test": "node testRunner.js",
     "postinstall": "node postInstall.js"
   },
-  "main": "./index.js"
+  "main": "./index.js",
+  "binary": {
+    "module_name": "nodejavabridge_bindings",
+    "module_path": "./lib/binding/",
+    "host": "https://node-java.s3.amazonaws.com/"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "bundledDependencies":["node-pre-gyp"],
   "scripts": {
     "preinstall": "node install glob; node postInstall.js",
-    "install": "node install.js",
+    "install": "npm install node-pre-gyp; node install.js",
     "test": "node testRunner.js"
   },
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "bundledDependencies":["node-pre-gyp"],
   "scripts": {
-    "preinstall": "npm install glob; node postInstall.js",
-    "install": "npm install node-pre-gyp; node install.js",
+    "install": "node install.js",
     "test": "node testRunner.js"
   },
   "main": "./index.js",

--- a/testRunner.js
+++ b/testRunner.js
@@ -14,7 +14,7 @@ var tests = glob.sync(path.join('testAsyncOptions', '*.js'));
 tests.unshift('test test8');  // Arrange to run the primary tests first, in a single process
 
 function runTest(testArgs, done) {
-  var cmd = 'node_modules/.bin/nodeunit ' + testArgs;
+  var cmd = 'node_modules' + path.sep + '.bin' + path.sep + 'nodeunit ' + testArgs;
   childProcess.exec(cmd, function (error, stdout, stderr) {
     // It appears that nodeunit merges error output into the stdout
     // so these three lines are probably useless.


### PR DESCRIPTION
I have created a fork that uses node-pre-gyp to handle pre-built assemblies. In my initial testing, it seems to work well. The process for building and publishing the assemblies is pretty simple:

```
node-pre-gyp rebuild
node-pre-gyp package publish
```

I'd be happy to give a select number of people push access to the S3 repository I created... I have pre-built assemblies for the latest version of node-java on linux 64bit (two different versions of node) and for windows 32bit.

I believe this would drammatically simplify the installation of the node-java module.

Also note that I changed the path to the binary that is used by require() to "lib", because that is the default location where node-gyp and node-pre-gyp compiles and/or extracts the assemblies to.