### PR TITLE
Add node v4.x to travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
   - oraclejdk8
   - oraclejdk7
 env:
+  - NODE_VERSION=4 CC=clang CXX=clang++
   - NODE_VERSION="0.12"
   - NODE_VERSION="0.10"
 before_install:


### PR DESCRIPTION
@joeferner It seems that the v8 in node 4 now requires clang instead of gcc. Travis defaults to gcc, but we can specify clang by setting the env variables CC and CXX.

FYI I only added one line to the .travis.yml, but I switched the newlines from CRLF to unix, so the diff below shows every line changing.

Fixes #255.
