### PR TITLE
Allow before/after functions that don't take a callback

### DIFF
--- a/lib/nodeJavaBridge.js
+++ b/lib/nodeJavaBridge.js
@@ -50,10 +50,19 @@ var clients = [];
 // If the client doesn't need to be called back for either function, it can pass null or undefined.
 // Both before and after here are assumed to be functions that accept one argument that is a node-callback function.
 java.registerClient = function(before, after) {
+  var before_, after_;
   if (java.isJvmCreated()) {
     throw new Error('java.registerClient() called after JVM already created.');
   }
-  clients.push({before: before, after: after});
+  before_ = (before && before.length === 0) ?
+    function(cb) { before(); cb(); } :
+    before;
+
+  after_ = (after && after.length === 0) ?
+    function(cb) { after(); cb(); } :
+    after;
+
+  clients.push({before: before_, after: after_});
 }
 
 // A client can register function hooks to be called before and after the JVM is created.

--- a/testAsyncOptions/testClientBeforeSyncThrows.js
+++ b/testAsyncOptions/testClientBeforeSyncThrows.js
@@ -1,0 +1,33 @@
+// testClientBeforeSyncThrows.js
+
+var _ = require('lodash');
+var java = require("../");
+var nodeunit = require("nodeunit");
+
+module.exports = {
+
+  clientBeforeSyncThrows: function(test) {
+    test.expect(6);
+    test.ok(!java.isJvmCreated());
+
+    java.asyncOptions = {
+      syncSuffix: "Sync",
+    };
+
+    function before() {
+      test.ok(!java.isJvmCreated());
+      throw new Error('dummy error');
+    }
+
+    java.registerClient(before);
+
+    java.ensureJvm(function(err) {
+      test.ok(_.isObject(err));
+      test.ok(err instanceof Error);
+      test.strictEqual(err.message, 'dummy error');
+      test.ok(!java.isJvmCreated());
+      test.done();
+    });
+  }
+
+}

--- a/testAsyncOptions/testDefacto.js
+++ b/testAsyncOptions/testDefacto.js
@@ -19,14 +19,12 @@ module.exports = {
       asyncSuffix: ""
     };
 
-    function before(callback) {
+    function before() {
       test.ok(!java.isJvmCreated());
-      callback();
     }
 
-    function after(callback) {
+    function after() {
       test.ok(java.isJvmCreated());
-      callback();
     }
 
     java.registerClient(before, after);


### PR DESCRIPTION
With this change, we can skip the callback noise for cases that don't
need it, for example:

`java.registerClient(function() { do.some.thing(); });`