### PR TITLE
Node Java doesn't work on different Platforms of OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ Notes:
 
 ### Installation OSX
 
-* If you run into strange runtime issues, it could be because the Oracle JDK does not advertise itself as available for JNI.  See [Issue 90](https://github.com/joeferner/node-java/issues/90#issuecomment-45613235) for more details and manual workarounds.  If this does occur for you, please update the issue.
+PREREQUISITES:
+
+* OSX JDK needs JNI feature enabled.  
+Run (https://gist.github.com/pudquick/349f063c242239952a2e#file-modify_java-py) to guarantee all JDKs have JNI enabled.
+
+* Add a symlink to your JDK.
+cd /Library/Application Support/ExportData/
+sudo ln -s /Library/Java/JavaVirtualMachines/<JDK-VERSION>/Contents/Home javaLocation
+
+where JDK-VERSION is the version of the JDK you wish to use.
+
 
 ### Installation Windows
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ PREREQUISITES:
 Run (https://gist.github.com/pudquick/349f063c242239952a2e#file-modify_java-py) to guarantee all JDKs have JNI enabled.
 
 * Add a symlink to your JDK.
+```bash
 cd /Library/Application Support/ExportData/
 sudo ln -s /Library/Java/JavaVirtualMachines/<JDK-VERSION>/Contents/Home javaLocation
+```
 
 where JDK-VERSION is the version of the JDK you wish to use.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Run (https://gist.github.com/pudquick/349f063c242239952a2e#file-modify_java-py) 
 
 * Add a symlink to your JDK.
 ```bash
+sudo mkdir /Library/Application Support/ExportData/
 cd /Library/Application Support/ExportData/
 sudo ln -s /Library/Java/JavaVirtualMachines/<JDK-VERSION>/Contents/Home javaLocation
 ```

--- a/binding.gyp
+++ b/binding.gyp
@@ -135,8 +135,8 @@
                     '<(javahome)/include/darwin'
                   ],
                   'libraries': [
-                    '-L<(javahome)/jre/lib/server',
-                    '-Wl,-rpath,<(javahome)/jre/lib/server',
+                    '-L/Library/Application\ Support/ExportData/javaLocation/jre/lib/server',
+                    '-Wl,-rpath,/Library/Application\ Support/ExportData/javaLocation/jre/lib/server',
                     '-ljvm'
                   ],
                 },


### PR DESCRIPTION
The primary issue with Node-Java on OSX is that the path to the Java SDK is embedded in the compiled code.  This used to be OK in OSX, but the most recent versions of OSX no longer bundle Java.  Users have to manually install it, and may have different versions in different locations.  

This means after the code is built, Java is not necessarily accessible in the fixed location provided with the build.  A solution (included in this pull request) is to compile with a link to the version of Java you wish to use.  The link needs to be defined (currently in /Library/Application Support/ExportData/) which is probably not ideal.  Could easily be modified to something like /Library/Application Support/node-java/.
