### PR TITLE
fix for ppc64le build that does not override target_arch in node-gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,12 +12,6 @@
       ['uname_m=="s390" or uname_m=="s390x"', {
         'target_arch': 's390'
       }],
-      ['uname_m=="ppc64"', {
-        'target_arch': 'ppc64'
-      }],
-      ['uname_m=="ppc64le"', {
-        'target_arch': 'ppc64le'
-      }],
       ['OS=="win"', {
         'javahome%': '<!(node findJavaHome.js)'
       }],

--- a/find_java_libdir.sh
+++ b/find_java_libdir.sh
@@ -28,7 +28,7 @@ main () {
   else
     jre_dir="${java_home}/lib"
   fi
-  
+
   local lib_dir=""
   if [[ "${os}" == "linux" && ! "${java_version}" =~ (6|7|8) ]]; then
     # no arch on JDK 9+
@@ -42,9 +42,8 @@ main () {
   elif [[ "${os}" == "linux" ]] && [[ "${target_arch}" == "s390x" || "${target_arch}" == "s390" ]]; then
     if [[ -d ${jre_dir}/s390x/classic ]]; then lib_dir="${jre_dir}"/s390x/classic; else lib_dir="${jre_dir}"/s390/classic; fi
   elif [[ "${os}" == "linux" ]] && [[ "${target_arch}" == "ppc64" || "${target_arch}" == "ppc" ]]; then
-    if [[ -d ${jre_dir}/ppc64/classic ]]; then lib_dir="${jre_dir}"/ppc64/classic; fi
-  elif [[ "${os}" == "linux" ]] && [[ "${target_arch}" == "ppc64le" || "${target_arch}" == "ppcle" ]]; then
-    if [[ -d ${jre_dir}/ppc64le/classic ]]; then lib_dir="${jre_dir}"/ppc64le/classic; else lib_dir="${jre_dir}"/ppc64le/server; fi
+    target_arch=`uname -m`
+    if [[ -d ${jre_dir}/${target_arch}/classic ]]; then lib_dir="${jre_dir}"/${target_arch}/classic; else lib_dir="${jre_dir}"/${target_arch}/server; fi
   elif [[ "${os}" == "mac" ]]; then
     lib_dir="${jre_dir}/server"
   else


### PR DESCRIPTION
Another possible commit that deals with this issue fully. Not sure if it's the right way to do it but it works. Rather than trying to set the *target_arch* variable in *binding.gyp* it seemed just as reasonable to leave the target architecture as ppc64 as far as node-gyp is concerned. In this version find_java_libdir.sh gets the result of `uname -m` and uses that as the architecture value in the Java lib path.

```
elif [[ "${os}" == "linux" ]] && [[ "${target_arch}" == "ppc64" || "${target_arch}" == "ppc" ]]; then
    target_arch=`uname -m`
    if [[ -d ${jre_dir}/${target_arch}/classic ]]; then lib_dir="${jre_dir}"/${target_arch}/classic; else lib_dir="${jre_dir}"/${target_arch}/server; fi
```

This works on my ppc64le environment and it's no longer necessary to override the node-gyp environment with `--target_arch=ppc64le`.