### PR TITLE
feat: make node 12 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - NODE_VERSION=7 CC=clang CXX=clang++
   - NODE_VERSION=8 CC=clang CXX=clang++
   - NODE_VERSION=11 CC=clang CXX=clang++
+  - NODE_VERSION=12 CC=clang CXX=clang++
 before_install:
   - nvm install $NODE_VERSION
 before_script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "java",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1140,9 +1140,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "neo-async": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "find-java-home": "0.2.0",
     "glob": "7.1.3",
     "lodash": "4.17.14",
-    "nan": "2.11.1"
+    "nan": "2.14.0"
   },
   "devDependencies": {
     "chalk": "2.4.1",

--- a/src/java.h
+++ b/src/java.h
@@ -16,7 +16,7 @@
 
 class Java : public Nan::ObjectWrap {
 public:
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
   JavaVM* getJvm() { return m_jvm; }
   JNIEnv* getJavaEnv() { return m_env; } // can only be used safely by the main thread as this is the thread it belongs to
   jobject getClassLoader() { return m_classLoader; }

--- a/src/javaObject.h
+++ b/src/javaObject.h
@@ -13,7 +13,7 @@ class Java;
 
 class JavaObject : public Nan::ObjectWrap {
 public:
-  static void Init(v8::Handle<v8::Object> target);
+  static void Init(v8::Local<v8::Object> target);
   static v8::Local<v8::Object> New(Java* java, jobject obj);
   static v8::Local<v8::Object> NewProxy(Java* java, jobject obj, DynamicProxyData* dynamicProxyData);
 

--- a/src/nodeJavaBridge.cpp
+++ b/src/nodeJavaBridge.cpp
@@ -3,7 +3,7 @@
 #include "javaObject.h"
 
 extern "C" {
-  static void init(v8::Handle<v8::Object> target) {
+  static void init(v8::Local<v8::Object> target) {
     Java::Init(target);
     JavaObject::Init(target);
   }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -339,7 +339,11 @@ jobject v8ToJava(JNIEnv* env, v8::Local<v8::Value> arg) {
   }
 
   if(arg->IsString()) {
+#if NODE_MAJOR_VERSION > 7
     v8::String::Value val(v8::Isolate::GetCurrent(), arg->ToString(Nan::GetCurrentContext()).ToLocalChecked());
+#else
+    v8::String::Value val(arg->ToString(Nan::GetCurrentContext()).ToLocalChecked());
+#endif
     return env->NewString(*val, val.length());
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -339,7 +339,7 @@ jobject v8ToJava(JNIEnv* env, v8::Local<v8::Value> arg) {
   }
 
   if(arg->IsString()) {
-    v8::String::Value val(arg->ToString());
+    v8::String::Value val(v8::Isolate::GetCurrent(), arg->ToString(Nan::GetCurrentContext()).ToLocalChecked());
     return env->NewString(*val, val.length());
   }
 
@@ -644,7 +644,7 @@ v8::Local<v8::Value> javaArrayToV8(Java* java, JNIEnv* env, jobjectArray objArra
   default:
     for(jsize i=0; i<arraySize; i++) {
         jobject obj = env->GetObjectArrayElement(objArray, i);
-        v8::Handle<v8::Value> item = javaToV8(java, env, obj);
+        v8::Local<v8::Value> item = javaToV8(java, env, obj);
         result->Set(i, item);
     }
     break;

--- a/src/utils.h
+++ b/src/utils.h
@@ -117,7 +117,7 @@ void unref(DynamicProxyData* dynamicProxyData);
     return;                                                                                  \
   }                                                                                          \
   v8::Local<v8::String> _##ARGNAME##_obj = v8::Local<v8::String>::Cast(info[argsStart]);     \
-  v8::String::Utf8Value _##ARGNAME##_val(_##ARGNAME##_obj);                                  \
+  Nan::Utf8String _##ARGNAME##_val(_##ARGNAME##_obj);                                  \
   std::string ARGNAME = *_##ARGNAME##_val;                                                   \
   argsStart++;
 
@@ -138,11 +138,11 @@ void unref(DynamicProxyData* dynamicProxyData);
 #define EXCEPTION_CALL_CALLBACK(JAVA, STRBUILDER) \
   std::ostringstream errStr;                                                            \
   errStr << STRBUILDER;                                                                 \
-  v8::Handle<v8::Value> error = javaExceptionToV8(JAVA, env, errStr.str());             \
-  v8::Handle<v8::Value> argv[2];                                                        \
+  v8::Local<v8::Value> error = javaExceptionToV8(JAVA, env, errStr.str());             \
+  v8::Local<v8::Value> argv[2];                                                        \
   argv[0] = error;                                                                      \
   argv[1] = Nan::Undefined();                                                           \
-  v8::Function::Cast(*callback)->Call(Nan::GetCurrentContext()->Global(), 2, argv);
+  Nan::Call(callback.As<v8::Function>(), Nan::GetCurrentContext()->Global(), 2, argv);
 
 #define END_CALLBACK_FUNCTION(MSG) \
   if(callbackProvided) {                                     \


### PR DESCRIPTION
* Updates `nan`
* Switches a bunch of V8 methods to use the `Nan` helpers to retain interop and support node 12
* Manually fixes a few bits of usage that nan doesn't handle

Tested locally, all tests pass on node 12

Closes #473
Closes #470