### PR TITLE
Fix concurrency

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -37,13 +37,17 @@ struct DynamicProxyData {
   std::string interfaceName;
   Nan::Persistent<v8::Object> functions;
   Nan::Persistent<v8::Value> jsObject;
+  unsigned int markerEnd;
+};
+
+struct DynamicProxyJsCallData {
+  DynamicProxyData *dynamicProxyData;
   std::string methodName;
   jobjectArray args;
   jobject result;
   std::string throwableClass;
   std::string throwableMessage;
   int done;
-  unsigned int markerEnd;
 };
 
 #define DYNAMIC_PROXY_DATA_MARKER_START 0x12345678


### PR DESCRIPTION
Fixes #262 

If you're on the v8 thread and call a proxy, node-java just calls the javascript directly.  If not, node-java queues the javascript call to get it in the main loop, then checks every 100ms to see if the javascript is done.
When the proxy object is created in C++ (based on call from javascript), a java object of type NodeDynamicProxyClass is instantiated with a single DynamicProxyData object, which pointer is passed to the constructor as a `long`.  This is the same pointer that gets passed back to Java_node_NodeDynamicProxyClass_callJs, and gets used for every subsequent call.  If two calls are occurring simultaneously or recursively, though, then it would get clobbered.
The changes here fix that by creating a separate callData object for each call.
We also switch to using `uv_async_send` instead of `uv_queue_work`, to fix a queue corruption problem caused by calling `uv_queue_work` from threads other than the main v8 thread.