### PR TITLE
Fixed Dockerfile 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker run -it joeferner/node-java bash
 Then inside the docker container create a directory and run
 
 ```bash
-npm install java
+npm install --unsafe-perm java
 ```
 
 Then create a file called `test.js` with the following contents

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,17 +5,17 @@ RUN apt-get install -y curl wget tar git python build-essential
 
 # Java
 RUN \
-  wget --continue --no-check-certificate -O /opt/jdk-8u191-linux-x64.tar.gz --header "Cookie: oraclelicense=a" http://download.oracle.com/otn-pub/java/jdk/8u191-b12/2787e4a523244c269598db4e85c51e0c/jdk-8u191-linux-x64.tar.gz \
-  && tar -xzf /opt/jdk-8u191-linux-x64.tar.gz -C /opt \
-  && rm /opt/jdk-8u191-linux-x64.tar.gz \
-  && ln -s /opt/jdk1.8.0_191 /opt/jdk
+  wget https://javadl.oracle.com/webapps/download/GetFile/1.8.0_261-b12/a4634525489241b9a9e1aa73d9e118e6/linux-i586/jdk-8u261-linux-x64.tar.gz -O /opt/jdk-8u261-linux-x64.tar.gz \
+  && tar -xzf /opt/jdk-8u261-linux-x64.tar.gz -C /opt \
+  && rm /opt/jdk-8u261-linux-x64.tar.gz \
+  && ln -s /opt/jdk1.8.0_261 /opt/jdk
 ENV PATH $PATH:/opt/jdk/bin
 ENV JAVA_HOME /opt/jdk
 ENV _JAVA_OPTIONS -Djava.net.preferIPv4Stack=true
 
 # Node
 RUN \
-  wget -O /opt/node-v11.2.0-linux-x64.tar.gz http://nodejs.org/dist/latest/node-v11.2.0-linux-x64.tar.gz \
+  wget -O /opt/node-v11.2.0-linux-x64.tar.gz https://nodejs.org/dist/v11.2.0/node-v11.2.0-linux-x64.tar.gz \
   && tar -xzf /opt/node-v11.2.0-linux-x64.tar.gz -C /opt \
   && rm /opt/node-v11.2.0-linux-x64.tar.gz \
   && ln -s /opt/node-v11.2.0-linux-x64 /opt/node


### PR DESCRIPTION
Fixed the Dockerfile and updated jdk to `jdk-8u261-linux-x64.tar.gz` and fixed the nodejs path, now the Docker container builds.

Inside the container, installation should be done as `npm install --unsafe-perm java` to get around the following error:

```
> java@0.12.1 install /root/testing/node_modules/java
> node-gyp rebuild

gyp WARN EACCES user "root" does not have permission to access the dev dir "/root/.node-gyp/11.2.0"
gyp WARN EACCES attempting to reinstall using temporary dev dir "/root/testing/node_modules/java/.node-gyp"
gyp WARN install got an error, rolling back install
gyp WARN install got an error, rolling back install
gyp ERR! configure error
gyp ERR! stack Error: EACCES: permission denied, stat '/root/testing/node_modules/java/.node-gyp/11.2.0'
gyp ERR! System Linux 4.19.76-linuxkit
gyp ERR! command "/opt/node-v11.2.0-linux-x64/bin/node" "/opt/node-v11.2.0-linux-x64/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /root/testing/node_modules/java
gyp ERR! node -v v11.2.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
npm WARN testing@1.0.0 No description
npm WARN testing@1.0.0 No repository field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! java@0.12.1 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the java@0.12.1 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2020-08-13T13_35_11_908Z-debug.log
```

Updated README accordingly.