### PR TITLE
Improve visibility of install problems 

### DIFF
--- a/findJavaHome.js
+++ b/findJavaHome.js
@@ -1,6 +1,6 @@
 require('find-java-home')(function(err, home){
-  if(err){
-    console.error("[node-java] "+err);
+  if (err || !home) {
+    if (!err) err = Error('Unable to determine Java home location');
     process.exit(1);
   }
   process.stdout.write(home);

--- a/find_java_libdir.sh
+++ b/find_java_libdir.sh
@@ -66,8 +66,8 @@ main () {
     fi
   fi
 
-  if [[ -z "${lib_dir}" ]]; then
-    error "Can't find lib dir for ${os} ${target_arch}, java home: ${java_home}"
+  if [[ ! -d "${lib_dir}" ]]; then
+    error "Can't find lib dir '${lib_dir}' for ${os} ${target_arch}, java home: ${java_home}"
   fi
   echo "${lib_dir}"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "java",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1282,9 +1282,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {


### PR DESCRIPTION
Hi @joeferner,

I found while looking at some platform-specific installation problems, that these errors were not visible. This PR should help to address this. It adds some checks to make sure we have a valid Java home directory before attempting the build.

I was also going to fix the version on package-lock file (omitted from `1621a7a` when `v0.12.2` was released), but Dependabot had already fixed it, so I'm including that here also.

I should have another PR ready soon to address the actual platform-specific issues, but that's a little more involved, so figured it makes sense to separate the PR's.