### PR TITLE
Support thread workers

### DIFF
--- a/src/nodeJavaBridge.cpp
+++ b/src/nodeJavaBridge.cpp
@@ -8,6 +8,8 @@ extern "C" {
     JavaObject::Init(target);
   }
 
+  NAN_MODULE_WORKER_ENABLED(nodejavabridge_bindings, init);
+
   NODE_MODULE(nodejavabridge_bindings, init);
 }
 


### PR DESCRIPTION
Run node-java in node thread worker.
* We still have to import node-java at least once in our main thread code due to [context-aware addons](https://nodejs.org/docs/latest-v16.x/api/addons.html#:~:text=to%20NODE_MODULE().-,Context%2Daware%20addons,-%23).