### PR TITLE
fix empty string promise suffix

### DIFF
--- a/lib/nodeJavaBridge.js
+++ b/lib/nodeJavaBridge.js
@@ -30,6 +30,10 @@ java.classpath.pushDir = function(dir) {
 };
 java.nativeBindingLocation = binaryPath;
 
+var callStaticMethod = java.callStaticMethod;
+var callStaticMethodSync = java.callStaticMethodSync;
+var newInstanceSync = java.newInstanceSync;
+
 var syncSuffix = undefined;
 var asyncSuffix = undefined;
 var ifReadOnlySuffix = '_';
@@ -230,7 +234,7 @@ java.import = function(name) {
     for (var i = 0; i < arguments.length; i++) {
       args.push(arguments[i]);
     }
-    return java.newInstanceSync.apply(java, args);
+    return newInstanceSync.apply(java, args);
   };
   var i;
 
@@ -270,17 +274,17 @@ java.import = function(name) {
 
       if (_.isString(syncSuffix)) {
         var syncName = usableName(methodName + syncSuffix);
-        result[syncName] = java.callStaticMethodSync.bind(java, name, methodName);
+        result[syncName] = callStaticMethodSync.bind(java, name, methodName);
       }
 
       if (_.isString(asyncSuffix)) {
         var asyncName = usableName(methodName + asyncSuffix);
-        result[asyncName] = java.callStaticMethod.bind(java, name, methodName);
+        result[asyncName] = callStaticMethod.bind(java, name, methodName);
       }
 
       if (promisify && _.isString(promiseSuffix)) {
         var promiseName = usableName(methodName + promiseSuffix);
-        result[promiseName] = promisify(java.callStaticMethod.bind(java, name, methodName));
+        result[promiseName] = promisify(callStaticMethod.bind(java, name, methodName));
       }
     }
   }


### PR DESCRIPTION
Only notable behaviour broken with empty string promise suffix was static method calls on imported classes.
(java.import('...').staticMethod())

This is due to double-promisification of callStaticMethod function. This change extracts raw, pre-promisified methods used later in runtime by java bridge as local variables and uses that instead.

This also fixes a similar breakage if someone set "Sync" as promise suffix.